### PR TITLE
Handle phaser blocks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -87,10 +87,11 @@ module.exports = grammar({
     statement_label: $ => seq(field('label', $.bareword), ':', field('statement', $._fullstmt)),
 
     _barestmt: $ => choice(
-      /* TODO: sub */
       $.package_statement,
       $.use_version_statement,
       $.use_statement,
+      /* TODO: sub */
+      $.phaser_statement,
       $.if_statement,
       $.unless_statement,
       /* TODO: given/when/default */
@@ -113,6 +114,12 @@ module.exports = grammar({
       optional($._listexpr),
       $._PERLY_SEMICOLON
     ),
+
+    // perly.y's grammar just considers a phaser to be a `sub` with a special
+    // name and lacking the `sub` keyword, but most tree consumers are likely
+    // to care about distinguishing it
+    phaser_statement: $ => seq(field('phase', $._PHASE_NAME), $.block),
+
     if_statement: $ =>
       seq('if', '(', field('condition', $._expr), ')',
         field('block', $.block),
@@ -482,6 +489,8 @@ module.exports = grammar({
     _KW_USE: $ => choice('use', 'no'),
     _KW_FOR: $ => choice('for', 'foreach'),
     _LOOPEX: $ => choice('last', 'next', 'redo'),
+
+    _PHASE_NAME: $ => choice('BEGIN', 'INIT', 'CHECK', 'UNITCHECK', 'END'),
 
     /****
      * Misc bits

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -11,6 +11,8 @@
   "undef"
 ] @keyword
 
+[ "BEGIN" "INIT" "CHECK" "UNITCHECK" "END" ] @keyword.phaser
+
 [
   "or" "and"
   "eq" "ne" "cmp" "lt" "le" "ge" "gt"

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -236,3 +236,15 @@ ITEM: while(@items) { }
     statement: (while_statement
       condition: (array)
       block: (block))))
+================================================================================
+phasers
+================================================================================
+BEGIN { 123; }
+END { 456; }
+--------------------------------------------------------------------------------
+
+(source_file
+  (phaser_statement
+    (block (expression_statement (number))))
+  (phaser_statement
+    (block (expression_statement (number)))))

--- a/test/highlight/statements.pm
+++ b/test/highlight/statements.pm
@@ -91,3 +91,9 @@ ITEM: while(@items) {
 goto FOO;
 # <- keyword
 #    ^ label
+BEGIN { 123; }
+# <- keyword.phaser
+#       ^ number
+END { 456; }
+# <- keyword.phaser
+#     ^ number


### PR DESCRIPTION
Highlight them as `@keyword.phaser` because nvim (and probably other editors) like to distinguish them from just regular keywords.