### PR TITLE
Try harder to look for certain token types after ERROR

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -70,6 +70,8 @@ module.exports = grammar({
     $._gobbled_content,
     $.attribute_value,
     $.prototype_or_signature,
+    /* error condition must always be last; we don't use this in the grammar */
+    $._ERROR
   ],
   extras: $ => [
     /\s|\\\r?\n/,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -36,6 +36,8 @@ enum TokenType {
   TOKEN_GOBBLED_CONTENT,
   TOKEN_ATTRIBUTE_VALUE,
   TOKEN_PROTOTYPE_OR_SIGNATURE,
+  /* error condition is always last */
+  TOKEN_ERROR
 };
 
 struct LexerState {
@@ -172,9 +174,7 @@ bool tree_sitter_perl_external_scanner_scan(
 ) {
   struct LexerState *state = payload;
 
-  // The only time we'd ever be looking for both BEGIN and END is during an error
-  // condition. Abort in that case
-  bool is_ERROR = valid_symbols[TOKEN_Q_STRING_BEGIN] && valid_symbols[TOKEN_QUOTELIKE_END];
+  bool is_ERROR = valid_symbols[TOKEN_ERROR];
 
   if(!is_ERROR && valid_symbols[TOKEN_GOBBLED_CONTENT]) {
     while (!lexer->eof(lexer)) 


### PR DESCRIPTION
After an ERROR condition it can be a while before tree-sitter has recovered enough tree state. At present, it might get confused enough to miss the `"` of a string-literal (e.g. in a `croak "message here") or the `=head...` of the start of some POD immediately after some syntax it doesn't yet recognise. This confuses the remaining syntax a lot more than necessary.

By attempting to resume certain "unlikely to be wrong" token types such as quoted strings or POD, we recover more quickly after encountering syntax not yet recognised by the parser.