### PR TITLE
Support some builtin funcs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -479,7 +479,7 @@ module.exports = grammar({
 
     scalar:   $ => seq('$',  $._indirob),
     array:    $ => seq('@',  $._indirob),
-    hash:     $ => seq('%',  $._indirob),
+    hash:     $ => seq(token(prec(2, '%')), $._indirob),
     arraylen: $ => seq('$#', $._indirob),
     // perly.y calls this `star`
     glob:     $ => seq('*',  $._indirob),

--- a/grammar.js
+++ b/grammar.js
@@ -301,15 +301,11 @@ module.exports = grammar({
        */
       $.require_expression,
       /* UNIOPSUB
-       * UNIOPSUB term
-       * FUNC0
-       * FUNC0 '(' ')'
-       * FUNC0OP
-       * FUNC0OP '(' ')'
-       * FUNC1 '(' ')'
-       * FUNC1 '(' expr ')'
-       * PMFUNC
-       */
+       * UNIOPSUB term */
+      $.func0op_call_expression,
+      /* FUNC1 '(' ')'
+       * FUNC1 '(' expr ') 
+       * PMFUNC */
       $.bareword,
       $._listop,
 
@@ -437,6 +433,9 @@ module.exports = grammar({
     require_expression: $ =>
       prec.left(TERMPREC.REQUIRE, seq('require', optional($._term))),
 
+    func0op_call_expression: $ =>
+      seq(field('function', $.func0op), optseq('(', ')')),
+
     loopex_expression: $ =>
       prec.left(TERMPREC.LOOPEX, seq(field('loopex', $._LOOPEX), optional($._term))),
     goto_expression: $ =>
@@ -542,6 +541,13 @@ module.exports = grammar({
     _LOOPEX: $ => choice('last', 'next', 'redo'),
 
     _PHASE_NAME: $ => choice('BEGIN', 'INIT', 'CHECK', 'UNITCHECK', 'END'),
+
+    // Anything toke.c calls FUN0 or FUN0OP; the distinction does not matter to us
+    func0op: $ => choice(
+      '__FILE__', '__LINE__', '__PACKAGE__', '__SUB__',
+      'break', 'fork', 'getppid', 'time', 'times', 'wait', 'wantarray',
+      /* TODO: all the end*ent, get*ent, set*ent, etc... */
+    ),
 
     /****
      * Misc bits

--- a/grammar.js
+++ b/grammar.js
@@ -303,9 +303,8 @@ module.exports = grammar({
       /* UNIOPSUB
        * UNIOPSUB term */
       $.func0op_call_expression,
-      /* FUNC1 '(' ')'
-       * FUNC1 '(' expr ') 
-       * PMFUNC */
+      $.func1op_call_expression,
+      /* PMFUNC */
       $.bareword,
       $._listop,
 
@@ -436,6 +435,12 @@ module.exports = grammar({
     func0op_call_expression: $ =>
       seq(field('function', $.func0op), optseq('(', ')')),
 
+    func1op_call_expression: $ =>
+      prec.left(TERMPREC.UNOP, seq(
+        field('function', $.func1op),
+        choice(optseq('(', optional($._expr), ')'), $._term),
+      )),
+
     loopex_expression: $ =>
       prec.left(TERMPREC.LOOPEX, seq(field('loopex', $._LOOPEX), optional($._term))),
     goto_expression: $ =>
@@ -547,6 +552,23 @@ module.exports = grammar({
       '__FILE__', '__LINE__', '__PACKAGE__', '__SUB__',
       'break', 'fork', 'getppid', 'time', 'times', 'wait', 'wantarray',
       /* TODO: all the end*ent, get*ent, set*ent, etc... */
+    ),
+
+    // Anything toke.c calls FUN1 or UNIOP; the distinction does not matter to us
+    func1op: $ => choice(
+      // UNI
+      'abs', 'alarm', 'chop', 'chdir', 'close', 'closedir', 'caller', 'chomp',
+      'chr', 'cos', 'chroot', 'defined', 'delete', 'dbmclose', 'exists', 'exit',
+      'eof', 'exp', 'each', 'fc', 'fileno', 'gmtime', 'getc', 'getpgrp',
+      'getprotobyname', 'getpwname', 'getpwuid', 'getpeername', 'getnetbyname',
+      'getsockname', 'getgrnam', 'getgrgid', 'hex', 'int', 'keys', 'lc',
+      'lcfirst', 'length', 'localtime', 'log', 'lock', 'lstat', 'oct', 'ord',
+      'prototype', 'pop', 'pos', 'quotemeta', 'reset', 'rand', 'rmdir',
+      'readdir', 'readline', 'readpipe', 'rewinddir', 'readlink', 'ref',
+      'scalar', 'shift', 'sin', 'sleep', 'sqrt', 'srand', 'stat', 'study',
+      'tell', 'telldir', 'tied', 'uc', 'ucfirst', 'untie', 'undef', 'umask',
+      'values', 'write',
+      /* TODO: all the set*ent */
     ),
 
     /****

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -63,3 +63,5 @@
 (function_call_expression (function) @function)
 (method_call_expression (method) @function.method)
 (method_call_expression invocant: (bareword) @type)
+
+(func0op_call_expression function: (_) @function.builtin)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -65,3 +65,4 @@
 (method_call_expression invocant: (bareword) @type)
 
 (func0op_call_expression function: (_) @function.builtin)
+(func1op_call_expression function: (_) @function.builtin)

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -83,3 +83,18 @@ Some::Module->new(1234);
       invocant:  (bareword)
       method:    (method)
       arguments: (number))))
+================================================================================
+Func0 Ops
+================================================================================
+__FILE__;
+wait;
+time();
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (func0op_call_expression (func0op)))
+  (expression_statement
+    (func0op_call_expression (func0op)))
+  (expression_statement
+    (func0op_call_expression (func0op))))

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -98,3 +98,29 @@ time();
     (func0op_call_expression (func0op)))
   (expression_statement
     (func0op_call_expression (func0op))))
+================================================================================
+Func1 Ops
+================================================================================
+defined $x;
+int($num);
+int;
+int();
+int $x, int $y;
+shift @arr;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (func1op_call_expression (func1op) (scalar)))
+  (expression_statement
+    (func1op_call_expression (func1op) (scalar)))
+  (expression_statement
+    (func1op_call_expression (func1op)))
+  (expression_statement
+    (func1op_call_expression (func1op)))
+  (expression_statement
+    (list_expression
+      (func1op_call_expression (func1op) (scalar))
+      (func1op_call_expression (func1op) (scalar))))
+  (expression_statement
+    (func1op_call_expression (func1op) (array))))

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -107,6 +107,7 @@ int;
 int();
 int $x, int $y;
 shift @arr;
+keys %hash;
 --------------------------------------------------------------------------------
 
 (source_file
@@ -123,4 +124,6 @@ shift @arr;
       (func1op_call_expression (func1op) (scalar))
       (func1op_call_expression (func1op) (scalar))))
   (expression_statement
-    (func1op_call_expression (func1op) (array))))
+    (func1op_call_expression (func1op) (array)))
+  (expression_statement
+    (func1op_call_expression (func1op) (hash))))

--- a/test/highlight/functions.pm
+++ b/test/highlight/functions.pm
@@ -37,3 +37,14 @@ wait;
 # <- function.builtin
 time();
 # <- function.builtin
+
+### FUNC1OPs
+defined $x;
+# <- function.builtin
+#       ^ variable.scalar
+int($num);
+# <- function.builtin
+#   ^ variable.scalar
+shift @arr;
+# <- function.builtin
+#     ^ variable.array

--- a/test/highlight/functions.pm
+++ b/test/highlight/functions.pm
@@ -26,3 +26,14 @@ Some::Module->new(1234);
 # <- type
 #             ^ function.method
 #                 ^ number
+
+### FUNC0OPs
+# no need to test them all, just do a few
+__FILE__;
+# <- function.builtin
+__LINE__;
+# <- function.builtin
+wait;
+# <- function.builtin
+time();
+# <- function.builtin

--- a/test/highlight/functions.pm
+++ b/test/highlight/functions.pm
@@ -48,3 +48,6 @@ int($num);
 shift @arr;
 # <- function.builtin
 #     ^ variable.array
+keys %hash
+# <- function.builtin
+#    ^ variable.hash


### PR DESCRIPTION
Adds recognition of the builtin funcs of the FUNC0 (0 args) and FUNC1 (1 arg) variety.

Does not yet add the list-shaped funcs, because I'm having trouble making list-associative precedence work properly for that. But this is a decent start.