### PR TITLE
Recognise attribute syntax on variable declarations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -401,12 +401,16 @@ module.exports = grammar({
       seq('do', $.block),
     ),
 
-    variable_declaration: $ =>
-      seq(choice('my', 'our'), choice(
-        field('variable', $.scalar),
-        field('variable', $.array),
-        field('variable', $.hash),
-        field('variables', $._paren_list_of_variables))),
+    variable_declaration: $ => prec.left(TERMPREC.QUESTION_MARK+1,
+      seq(
+        choice('my', 'our'),
+        choice(
+          field('variable', $.scalar),
+          field('variable', $.array),
+          field('variable', $.hash),
+          field('variables', $._paren_list_of_variables)),
+        optseq(':', optional(field('attributes', $.attrlist))))
+    ),
     localization_expression: $ =>
       seq('local', choice(
         field('variable', $.scalar),
@@ -490,10 +494,10 @@ module.exports = grammar({
 
     _ident_special: $ => /[0-9]+|\^[A-Z]|./,
 
-    attrlist: $ => seq(
+    attrlist: $ => prec.left(0, seq(
       $.attribute,
       repeat(seq(optional(':'), $.attribute))
-    ),
+    )),
     attribute: $ => seq(
       field('name', $.attribute_name),
       field('value', optional($.attribute_value))

--- a/test/corpus/variables
+++ b/test/corpus/variables
@@ -58,6 +58,20 @@ my %h = (6, 7);
   (expression_statement
     (assignment_expression (variable_declaration (hash)) (list_expression (number) (number)))))
 ================================================================================
+variable declarations with attributes
+================================================================================
+my $s :shared;
+my @a :lock;
+my ($S, @A, %h) :MyAttr(foo);
+--------------------------------------------------------------------------------
+(source_file
+  (expression_statement
+    (variable_declaration (scalar) (attrlist (attribute (attribute_name)))))
+  (expression_statement
+    (variable_declaration (array) (attrlist (attribute (attribute_name)))))
+  (expression_statement
+    (variable_declaration (scalar) (array) (hash) (attrlist (attribute (attribute_name) (attribute_value))))))
+================================================================================
 array elements
 ================================================================================
 $a[123];

--- a/test/highlight/variables.pm
+++ b/test/highlight/variables.pm
@@ -16,6 +16,9 @@ my ($x, undef, $z);
 our $PackageVar;
 # <- keyword
 #   ^ variable.scalar
+my $var :lock;
+# <- keyword
+#        ^ decorator
 $sref->$*;
 # <- variable.scalar
 #    ^^^^ variable.scalar


### PR DESCRIPTION
Needs some slightly hacky precedence fiddling because of the `COND ? my $var :attr ...` parsing problem.