### PR TITLE
Use tree-sitter to lex q/qq/qw (for great simplicity)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -52,14 +52,14 @@ module.exports = grammar({
   ],
   externals: $ => [
     /* ident-alikes */
-    $._q_string_begin,
-    $._qq_string_begin,
-    $._qw_list_begin,
     /* non-ident tokens */
+    $._saw_apostrophe,
+    $._saw_double_quote,
     $._PERLY_SEMICOLON,
     $._PERLY_BRACE_OPEN,
     $._HASHBRACK,
     /* immediates */
+    $._quotelike_begin,
     $._quotelike_end,
     $._q_string_content,
     $._qq_string_content,
@@ -583,7 +583,10 @@ module.exports = grammar({
 
     string_literal: $ => choice($._q_string),
     _q_string: $ => seq(
-      $._q_string_begin,
+      choice(
+        seq('q', $._quotelike_begin),
+        seq("'", $._saw_apostrophe)
+      ),
       repeat(choice(
         $._q_string_content,
         $.escape_sequence,
@@ -592,7 +595,10 @@ module.exports = grammar({
       $._quotelike_end
     ),
     interpolated_string_literal: $ => seq(
-      $._qq_string_begin,
+      choice(
+        seq('qq', $._quotelike_begin),
+        seq('"', $._saw_double_quote)
+      ),
       repeat(choice(
         $._qq_string_content,
         $.escape_sequence,
@@ -607,7 +613,8 @@ module.exports = grammar({
     ),
 
     quoted_word_list: $ => seq(
-      $._qw_list_begin,
+      'qw',
+      $._quotelike_begin,
       repeat(choice($._qw_list_content, $.escape_sequence, $.escaped_delimiter)),
       $._quotelike_end
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -53,8 +53,8 @@ module.exports = grammar({
   externals: $ => [
     /* ident-alikes */
     /* non-ident tokens */
-    $._saw_apostrophe,
-    $._saw_double_quote,
+    $._apostrophe,
+    $._double_quote,
     $._PERLY_SEMICOLON,
     $._PERLY_BRACE_OPEN,
     $._HASHBRACK,
@@ -585,7 +585,7 @@ module.exports = grammar({
     _q_string: $ => seq(
       choice(
         seq('q', $._quotelike_begin),
-        seq("'", $._saw_apostrophe)
+        $._apostrophe
       ),
       repeat(choice(
         $._q_string_content,
@@ -597,7 +597,7 @@ module.exports = grammar({
     interpolated_string_literal: $ => seq(
       choice(
         seq('qq', $._quotelike_begin),
-        seq('"', $._saw_double_quote)
+        $._double_quote
       ),
       repeat(choice(
         $._qq_string_content,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -174,6 +174,7 @@ bool tree_sitter_perl_external_scanner_scan(
   struct LexerState *state = payload;
 
   bool is_ERROR = valid_symbols[TOKEN_ERROR];
+  bool skipped_whitespace = false;
 
   if(!is_ERROR && valid_symbols[TOKEN_GOBBLED_CONTENT]) {
     while (!lexer->eof(lexer)) 
@@ -226,10 +227,11 @@ bool tree_sitter_perl_external_scanner_scan(
     }
   */
 
-  if(allow_identalike || valid_symbols[PERLY_SEMICOLON]);
+  if (iswspace(c)) {
+    skipped_whitespace = true;
     skip_whitespace(lexer);
-
-  c = lexer->lookahead;
+    c = lexer->lookahead;
+  }
 
   if(valid_symbols[PERLY_SEMICOLON]) {
     if(c == ';') {
@@ -364,7 +366,9 @@ bool tree_sitter_perl_external_scanner_scan(
 
   /* quotelike_begin is a zero-width assert, so it won't help in error recovery */
   if(valid_symbols[TOKEN_QUOTELIKE_BEGIN]) {
-      skip_whitespace(lexer);
+      if (skipped_whitespace && c == '#')
+        return false;
+
       int delim_close = close_for_open(lexer->lookahead);
       if(delim_close) {
         state->delim_open  = lexer->lookahead;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -17,15 +17,14 @@
 #include <wctype.h>
 
 enum TokenType {
-  /* ident-alikes */
-  TOKEN_Q_STRING_BEGIN,
-  TOKEN_QQ_STRING_BEGIN,
-  TOKEN_QW_LIST_BEGIN,
   /* non-ident tokens */
+  TOKEN_SAW_APOSTROPHE,
+  TOKEN_SAW_DOUBLE_QUOTE,
   PERLY_SEMICOLON,
   PERLY_BRACE_OPEN,
   TOKEN_HASHBRACK,
   /* immediates */
+  TOKEN_QUOTELIKE_BEGIN,
   TOKEN_QUOTELIKE_END,
   TOKEN_Q_STRING_CONTENT,
   TOKEN_QQ_STRING_CONTENT,
@@ -219,11 +218,13 @@ bool tree_sitter_perl_external_scanner_scan(
   }
 
   bool allow_identalike = false;
+  /* disabling for now, b/c we moved identalikes into the DSL
   for(int sym = 0; sym <= TOKEN_Q_STRING_BEGIN; sym++)
     if(valid_symbols[sym]) {
       allow_identalike = true;
       break;
     }
+  */
 
   if(allow_identalike || valid_symbols[PERLY_SEMICOLON]);
     skip_whitespace(lexer);
@@ -297,12 +298,8 @@ bool tree_sitter_perl_external_scanner_scan(
     c = lexer->lookahead;
   }
 
-  if(valid_symbols[TOKEN_Q_STRING_BEGIN]) {
-    /* Always expecting TOKEN_QQ_STRING_BEGIN as well */
-    if(ident_len == 1 && streq(ident, "q") ||
-        ident_len == 2 && streq(ident, "qq")) {
+  if(valid_symbols[TOKEN_QUOTELIKE_BEGIN]) {
       skip_whitespace(lexer);
-
       int delim_close = close_for_open(lexer->lookahead);
       if(delim_close) {
         state->delim_open  = lexer->lookahead;
@@ -317,52 +314,21 @@ bool tree_sitter_perl_external_scanner_scan(
       ADVANCE;
 
       DEBUG("Generic QSTRING open='%c' close='%c'\n", state->delim_open, state->delim_close);
-
-      if(ident_len == 1)
-        TOKEN(TOKEN_Q_STRING_BEGIN);
-      else
-        TOKEN(TOKEN_QQ_STRING_BEGIN);
-    }
-    if(ident_len == 0 && lexer->lookahead == '\'') {
-      ADVANCE;
-
-      state->delim_open = 0;
-      state->delim_close = '\'';
-      state->delim_count = 0;
-
-      TOKEN(TOKEN_Q_STRING_BEGIN);
-    }
-    if(ident_len == 0 && lexer->lookahead == '"') {
-      ADVANCE;
-
-      state->delim_open = 0;
-      state->delim_close = '"';
-      state->delim_count = 0;
-
-      TOKEN(TOKEN_QQ_STRING_BEGIN);
-    }
+      TOKEN(TOKEN_QUOTELIKE_BEGIN);
   }
-  if(valid_symbols[TOKEN_QW_LIST_BEGIN]) {
-    if(ident_len == 2 && streq(ident, "qw")) {
-      skip_whitespace(lexer);
+  if(valid_symbols[TOKEN_SAW_APOSTROPHE]) {
+    state->delim_open = 0;
+    state->delim_close = '\'';
+    state->delim_count = 0;
 
-      int delim_close = close_for_open(lexer->lookahead);
-      if(delim_close) {
-        state->delim_open  = lexer->lookahead;
-        state->delim_close = delim_close;
-      }
-      else {
-        state->delim_open  = 0;
-        state->delim_close = lexer->lookahead;
-      }
-      state->delim_count = 0;
+    TOKEN(TOKEN_SAW_APOSTROPHE);
+  }
+  if(valid_symbols[TOKEN_SAW_DOUBLE_QUOTE]) {
+    state->delim_open = 0;
+    state->delim_close = '"';
+    state->delim_count = 0;
 
-      ADVANCE;
-
-      DEBUG("QW LIST open='%c' close='%c'\n", state->delim_open, state->delim_close);
-
-      TOKEN(TOKEN_QW_LIST_BEGIN);
-    }
+    TOKEN(TOKEN_SAW_DOUBLE_QUOTE);
   }
 
   if(valid_symbols[TOKEN_POD]) {

--- a/test/corpus/literals
+++ b/test/corpus/literals
@@ -97,6 +97,20 @@ qq(a (string) here);
   (expression_statement (interpolated_string_literal))
   (expression_statement (interpolated_string_literal)))
 ================================================================================
+quotelike strings - tricky delimeter
+================================================================================
+q#hello#;
+q # this is a comment
+   (hello);
+# another comment so this can fail properly
+--------------------------------------------------------------------------------
+(source_file
+  (expression_statement (string_literal))
+  (expression_statement (string_literal (comment)))
+  (comment)
+)
+
+================================================================================
 Interpolation in "" strings
 ================================================================================
 "with $scalar";

--- a/test/corpus/literals
+++ b/test/corpus/literals
@@ -82,7 +82,8 @@ BAREWORD"string"
 --------------------------------------------------------------------------------
 
 (source_file
-  (ERROR) (expression_statement (interpolated_string_literal)))
+  (ERROR)
+  (expression_statement (interpolated_string_literal)))
 ================================================================================
 qq() strings
 ================================================================================

--- a/test/highlight/literals.pm
+++ b/test/highlight/literals.pm
@@ -71,3 +71,8 @@ qw| double escape \\|;
 qw/ hello \/ goodbye /;
 # <- string
 #         ^^ string.special
+q # this is a comment
+#  ^ comment
+#<- string
+  (string content);
+#  ^ string


### PR DESCRIPTION
This reshuffles some of the logic out of the scanner and into the tree-sitter DSL, which
is (IMO) a cleaner fix for #35
