### PR TITLE
Recognise the filetest operators as more func1ops

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -563,6 +563,8 @@ module.exports = grammar({
       'scalar', 'shift', 'sin', 'sleep', 'sqrt', 'srand', 'stat', 'study',
       'tell', 'telldir', 'tied', 'uc', 'ucfirst', 'untie', 'undef', 'umask',
       'values', 'write',
+      // filetest operators
+      ...("rwxoRWXOezsfdlpSbctugkTBMAC".split("").map(x => "-"+x))
       /* TODO: all the set*ent */
     ),
 

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -127,3 +127,18 @@ keys %hash;
     (func1op_call_expression (func1op) (array)))
   (expression_statement
     (func1op_call_expression (func1op) (hash))))
+================================================================================
+Filetest operators
+================================================================================
+-r "path";
+-w $path;
+-x _;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (func1op_call_expression (func1op) (interpolated_string_literal)))
+  (expression_statement
+    (func1op_call_expression (func1op) (scalar)))
+  (expression_statement
+    (func1op_call_expression (func1op) (bareword))))

--- a/test/highlight/functions.pm
+++ b/test/highlight/functions.pm
@@ -48,6 +48,14 @@ int($num);
 shift @arr;
 # <- function.builtin
 #     ^ variable.array
-keys %hash
+keys %hash;
 # <- function.builtin
 #    ^ variable.hash
+-r "path";
+# <- function.builtin
+#  ^ string
+-w $path;
+# <- function.builtin
+#  ^ variable.scalar
+-x _;
+# <- function.builtin


### PR DESCRIPTION
There's no special handling for the special `_` filename but it already works as a consequence of normal bareword-as-a-term handling. If we wanted it to highlight specially for whatever reason, we could put the filetest operators in their own category though. Unsure if it's worth it currently.