### PR TITLE
Allow folding of block statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -110,7 +110,7 @@ module.exports = grammar({
       $.until_statement,
       $.cstyle_for_statement,
       $.for_statement,
-      $.block,
+      alias($.block, $.block_statement),
       seq($.expression_statement, $._PERLY_SEMICOLON),
       ';', // this is not _PERLY_SEMICOLON so as not to generate an infinite stream of them
     ),

--- a/queries/fold.scm
+++ b/queries/fold.scm
@@ -11,6 +11,7 @@
  (until_statement)
  (for_statement)
  (cstyle_for_statement)
+ (block_statement)
  (phaser_statement)] @fold
 
 (anonymous_subroutine_expression) @fold

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -259,6 +259,6 @@ bare blocks
 --------------------------------------------------------------------------------
 
 (source_file
-  (block (expression_statement (number)))
-  (block (expression_statement (number)))
-  (block (block (expression_statement (number)))))
+  (block_statement (expression_statement (number)))
+  (block_statement (expression_statement (number)))
+  (block_statement (block_statement (expression_statement (number)))))


### PR DESCRIPTION
If we did fold on just `(block)` then too many things get folded in the wrong places when they're part of larger statements. By renaming block to block_statement when it appears at toplevel we can fold these bare blocks on their own.