### PR TITLE
Command strings (backtick / qx() )

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -55,6 +55,7 @@ module.exports = grammar({
     /* non-ident tokens */
     $._apostrophe,
     $._double_quote,
+    $._backtick,
     $._PERLY_SEMICOLON,
     $._PERLY_BRACE_OPEN,
     $._HASHBRACK,
@@ -608,6 +609,7 @@ module.exports = grammar({
     _literal: $ => choice(
       $.string_literal,
       $.interpolated_string_literal,
+      $.command_string,
     ),
 
     string_literal: $ => choice($._q_string),
@@ -647,6 +649,20 @@ module.exports = grammar({
       'qw',
       $._quotelike_begin,
       repeat(choice($._qw_list_content, $.escape_sequence, $.escaped_delimiter)),
+      $._quotelike_end
+    ),
+
+    command_string: $ => seq(
+      choice(
+        seq('qx', $._quotelike_begin),
+        $._backtick
+      ),
+      repeat(choice(
+        $._qq_string_content,
+        $.escape_sequence,
+        $.escaped_delimiter,
+        $._interpolated_expression,
+      )),
       $._quotelike_end
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -632,13 +632,15 @@ module.exports = grammar({
         $._qq_string_content,
         $.escape_sequence,
         $.escaped_delimiter,
-
-        /* interpolations */
-        $.scalar,
-        $.array,
-        // TODO: $arr[123], $hash{key}, ${expr}, @{expr}, ...
+        $._interpolated_expression,
       )),
       $._quotelike_end
+    ),
+
+    _interpolated_expression: $ => choice(
+      $.scalar,
+      $.array,
+      // TODO: $arr[123], $hash{key}, ${expr}, @{expr}, ...
     ),
 
     quoted_word_list: $ => seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -33,6 +33,7 @@
 (string_literal) @string
 (interpolated_string_literal) @string
 (quoted_word_list) @string
+(command_string) @string
 [(escape_sequence) (escaped_delimiter)] @string.special
 
 (_ (bareword) @string.special . "=>")

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -20,6 +20,7 @@ enum TokenType {
   /* non-ident tokens */
   TOKEN_APOSTROPHE,
   TOKEN_DOUBLE_QUOTE,
+  TOKEN_BACKTICK,
   PERLY_SEMICOLON,
   PERLY_BRACE_OPEN,
   TOKEN_HASHBRACK,
@@ -315,6 +316,14 @@ bool tree_sitter_perl_external_scanner_scan(
     state->delim_count = 0;
 
     TOKEN(TOKEN_DOUBLE_QUOTE);
+  }
+  if(valid_symbols[TOKEN_BACKTICK] && c == '`') {
+    ADVANCE_C;
+    state->delim_open = 0;
+    state->delim_close = '`';
+    state->delim_count = 0;
+
+    TOKEN(TOKEN_BACKTICK);
   }
 
   if(valid_symbols[TOKEN_POD]) {

--- a/test/corpus/literals
+++ b/test/corpus/literals
@@ -144,3 +144,27 @@ qw/ hello \/ goodbye /;
   (expression_statement (quoted_word_list))
   (expression_statement (quoted_word_list (escape_sequence)))
   (expression_statement (quoted_word_list (escaped_delimiter))))
+================================================================================
+`` strings
+================================================================================
+`command`;
+`command with (parens)`;
+`command with $interpolation`;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement (command_string))
+  (expression_statement (command_string))
+  (expression_statement (command_string (scalar))))
+================================================================================
+qx() strings
+================================================================================
+qx(command);
+qx(command with (parens));
+qx(command with $interpolation);
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement (command_string))
+  (expression_statement (command_string))
+  (expression_statement (command_string (scalar))))

--- a/test/highlight/literals.pm
+++ b/test/highlight/literals.pm
@@ -76,3 +76,11 @@ q # this is a comment
 #<- string
   (string content);
 #  ^ string
+
+`command`;
+# <- string
+`command with $scalar`;
+# <- string
+#             ^ variable.scalar
+qx(command);
+# <- string


### PR DESCRIPTION
Starts addressing #43

Doesn't quite resolve it all, because `qx'foo'` should not interpolate vars, but solving that would be difficult in the current structure, and it's a rarely encountered feature. We can come back to that another time.