### PR TITLE
Syntactically `local` can take any term expression (fixes #89)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -341,8 +341,7 @@ module.exports = grammar({
       $.do_expression,
       $.conditional_expression,
       $.refgen_expression,
-      /* KW_LOCAL
-       */
+      $.localization_expression,
       seq('(', $._expr, ')'),
       $.quoted_word_list,
       $.heredoc_token,
@@ -390,7 +389,6 @@ module.exports = grammar({
        * toke.c but we'll have to do it differently here
        */
       $.variable_declaration,
-      $.localization_expression,
 
       // legacy
       $.primitive,
@@ -479,15 +477,7 @@ module.exports = grammar({
           field('variables', $._decl_variable_list)),
         optseq(':', optional(field('attributes', $.attrlist))))
     ),
-    localization_expression: $ =>
-      seq('local', choice(
-        field('variable', $.scalar),
-        field('variable', $.array),
-        field('variable', $.hash),
-        field('variables', $._variable_list))),
-    _variable_list: $ => paren_list_of(
-      choice($.scalar, $.array, $.hash, $.undef_expression)
-    ),
+
     _decl_variable_list: $ => paren_list_of(
       choice(
         $.undef_expression,
@@ -496,6 +486,9 @@ module.exports = grammar({
         alias($._declare_hash, $.hash),
       )
     ),
+
+    localization_expression: $ =>
+      prec(TERMPREC.UNOP, seq('local', $._term)),
 
     // this has negative prec b/c it's only if the parens weren't eaten elsewhere
     stub_expression: $ => prec(-1, seq('(', ')')),

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -211,10 +211,22 @@ undef $var;
 local
 ================================================================================
 local $var;
+local $arr[$idx];
+local $hash{$key};
+local $SIG{INT} = sub { ... };
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (localization_expression (scalar))))
+  (expression_statement
+    (localization_expression (scalar)))
+  (expression_statement
+    (localization_expression (array_element_expression (container_variable) (scalar))))
+  (expression_statement
+    (localization_expression (hash_element_expression (container_variable) (scalar))))
+  (expression_statement
+    (assignment_expression
+      (localization_expression (hash_element_expression (container_variable) (autoquoted_bareword)))
+      (anonymous_subroutine_expression (block (expression_statement (yadayada)))))))
 ================================================================================
 return
 ================================================================================


### PR DESCRIPTION
Fixes #89

Admittedly this does remove the field names in the common cases; I couldn't work out how to preserve those.