### PR TITLE
Highlight attribute values as `@string`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -106,6 +106,7 @@ module.exports = grammar({
     $._dollar_in_regexp,
     $.pod,
     $._gobbled_content,
+    $._attribute_value_begin,
     $.attribute_value,
     $.prototype_or_signature,
     $._heredoc_delimiter,
@@ -622,7 +623,7 @@ module.exports = grammar({
     )),
     attribute: $ => seq(
       field('name', $.attribute_name),
-      field('value', optional($.attribute_value))
+      optseq($._attribute_value_begin, '(', field('value', $.attribute_value), ')'),
     ),
     attribute_name: $ => $._bareword,
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -67,7 +67,8 @@
 (require_expression (bareword) @type)
 
 (subroutine_declaration_statement name: (_) @function)
-(attrlist (attribute) @decorator)
+(attribute_name) @decorator
+(attribute_value) @string
 
 (goto_expression (label) @label)
 (loopex_expression (label) @label)

--- a/test/corpus/subroutines
+++ b/test/corpus/subroutines
@@ -110,3 +110,16 @@ sub barN ($x, $y, @z) { }
   (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
   (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
   (subroutine_declaration_statement (bareword) (prototype_or_signature) (block)))
+================================================================================
+Attribute plus signature
+================================================================================
+sub f :attr ($sig) {}
+--------------------------------------------------------------------------------
+(source_file
+  (subroutine_declaration_statement
+    (bareword)
+    (attrlist
+      (attribute
+        (attribute_name)))
+    (prototype_or_signature)
+    (block)))

--- a/test/highlight/subroutines.pm
+++ b/test/highlight/subroutines.pm
@@ -23,5 +23,4 @@ sub ghi :lvalue :const { }
 #                ^ decorator
 #
 sub abc :lvalue(1234) { }
-# <- keyword
-#        ^^^^^^^^^^^^ decorator
+#               ^^^^ string


### PR DESCRIPTION
Avoid highlighting the entire attribute declaration as `@decorator`; instead do just its name and treat its value like
 a plain string literal.

![screen](https://github.com/tree-sitter-perl/tree-sitter-perl/assets/350941/9bf15854-bfdf-4a0f-b1ff-34772d9bb4e1)