### PR TITLE
Avoid ADVANCE_C'ing past EOF when looking for double-character symbols

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -745,10 +745,12 @@ bool tree_sitter_perl_external_scanner_scan(
   }
 
   lexer->mark_end(lexer);
-  int c1 = c;
+  int c1 = c, c2 = 0;
   /* let's get the next lookahead */
-  ADVANCE_C;
-  int c2 = c;
+  if(c1) {
+    ADVANCE_C;
+    c2 = c;
+  }
 #define EQ2(s)  (c1 == s[0] && c2 == s[1])
 
   /* NOTE - we need this to NOT be valid_symbol guarded, b/c we need this to crash errant

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -747,7 +747,7 @@ bool tree_sitter_perl_external_scanner_scan(
   lexer->mark_end(lexer);
   int c1 = c, c2 = 0;
   /* let's get the next lookahead */
-  if(c1) {
+  if(!lexer->eof(lexer)) {
     ADVANCE_C;
     c2 = c;
   }


### PR DESCRIPTION
May be related to #107. Doesn't directly appear to fix it but nevertheless it was uncovered by it.