### PR TITLE
One approach for highlighting builtins

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,9 +1,9 @@
 name: Fuzz De Parser
 on:
-  push:
-    paths: 
-      - src/scanner.c
   workflow_dispatch:
+  # push:
+  #   paths: 
+  #     - src/scanner.c
 jobs:
   test:
     name: Fuzz Parser

--- a/grammar.js
+++ b/grammar.js
@@ -941,7 +941,7 @@ module.exports = grammar({
     // this pattern tries to encapsulate the joys of S_scan_ident in toke.c in perl core
     // _dollar_ident_zw takes care of the subtleties that distinguish $$; ( only $$
     // followed by semicolon ) from $$deref
-    _ident_special: $ => choice(/[0-9]+|\^([A-Z[?\^_]|])|./, seq('$', $._dollar_ident_zw) ),
+    _ident_special: $ => choice(/[0-9]+|\^([A-Z[?\^_]|])|\S/, seq('$', $._dollar_ident_zw) ),
 
     bareword: $ => prec.dynamic(1, $._bareword),
     // _bareword is at the very end b/c the lexer prefers tokens defined earlier in the grammar

--- a/grammar.js
+++ b/grammar.js
@@ -169,7 +169,7 @@ module.exports = grammar({
 
     // perly.y calls this labfullstmt
     statement_label: $ => seq(field('label', $.identifier), ':', field('statement', $._fullstmt)),
-    _semicolon: $ => alias($._PERLY_SEMICOLON, ';'),
+    _semicolon: $ => choice(';', $._PERLY_SEMICOLON),
 
     _barestmt: $ => choice(
       $.package_statement,

--- a/grammar.js
+++ b/grammar.js
@@ -612,13 +612,13 @@ module.exports = grammar({
     )),
     method: $ => choice($._METHCALL0, $.scalar),
 
-    scalar: $ => seq('$', $._var_indirob),
-    _declare_scalar: $ => seq('$', $._varname),
-    array: $ => seq('@', $._var_indirob),
-    _declare_array: $ => seq('@', $._varname),
-    _HASH_PERCENT: $ => alias(token(prec(2, '%')), '%'),
+    scalar:   $ => seq('$',  $._var_indirob),
+    _declare_scalar:   $ => seq('$',  $.varname),
+    array:    $ => seq('@',  $._var_indirob),
+    _declare_array:    $ => seq('@',  $.varname),
+    _HASH_PERCENT: $ => alias(token(prec(2, '%')), '%'), // self-aliasing b/c token
     hash:     $ => seq($._HASH_PERCENT, $._var_indirob),
-    _declare_hash:    $ => seq($._HASH_PERCENT,  $._varname),
+    _declare_hash:    $ => seq($._HASH_PERCENT,  $.varname),
 
     arraylen: $ => seq('$#', $._var_indirob),
     // perly.y calls this `star`
@@ -632,16 +632,16 @@ module.exports = grammar({
       $.scalar,
       $.block,
     ),
-    _varname: $ => choice(
+    varname: $ => choice(
       $._identifier,
       $._ident_special // TODO - not sure if we wanna make `my $1` error out
     ),
     // not all indirobs are alike; for variables, they have autoquoting behavior
     _var_indirob: $ => choice(
-      $._indirob,
+      alias($._indirob, $.varname),
       seq(
         $._PERLY_BRACE_OPEN,
-        choice($._bareword, $._autoquotables, $._ident_special, /\^[A-Z]\w*/),
+        alias(choice($._bareword, $._autoquotables, $._ident_special, /\^[A-Z]\w*/ ), $.varname),
         $._brace_end_zw, '}'
       )
     ),
@@ -936,6 +936,7 @@ module.exports = grammar({
 
     // prefer identifer to bareword where the grammar allows
     identifier: $ => prec(2, $._identifier),
+    // TODO - borken parsing for : $^_, $$, and ${^_varname}
     _identifier: $ => /[a-zA-Z_]\w*/,
     _ident_special: $ => /[0-9]+|\^[A-Z]|./,
 

--- a/grammar.js
+++ b/grammar.js
@@ -641,7 +641,7 @@ module.exports = grammar({
       alias($._indirob, $.varname),
       seq(
         $._PERLY_BRACE_OPEN,
-        alias(choice($._bareword, $._autoquotables, $._ident_special, /\^[A-Z]\w*/ ), $.varname),
+        alias(choice($._bareword, $._autoquotables, $._ident_special, /\^\w+/ ), $.varname),
         $._brace_end_zw, '}'
       )
     ),
@@ -936,9 +936,9 @@ module.exports = grammar({
 
     // prefer identifer to bareword where the grammar allows
     identifier: $ => prec(2, $._identifier),
-    // TODO - borken parsing for : $^_, $$, and ${^_varname}
+    // TODO - borken parsing for : $$
     _identifier: $ => /[a-zA-Z_]\w*/,
-    _ident_special: $ => /[0-9]+|\^[A-Z]|./,
+    _ident_special: $ => /[0-9]+|\^([A-Z[?\^_]|])|./,
 
     bareword: $ => prec.dynamic(1, $._bareword),
     // _bareword is at the very end b/c the lexer prefers tokens defined earlier in the grammar

--- a/grammar.js
+++ b/grammar.js
@@ -131,6 +131,7 @@ module.exports = grammar({
     $._PERLY_COMMA_continue,
     $._fat_comma_zw,
     $._brace_end_zw,
+    $._dollar_ident_zw,
     /* zero-width high priority token */
     $._NONASSOC,
     /* error condition must always be last; we don't use this in the grammar */
@@ -936,9 +937,11 @@ module.exports = grammar({
 
     // prefer identifer to bareword where the grammar allows
     identifier: $ => prec(2, $._identifier),
-    // TODO - borken parsing for : $$
     _identifier: $ => /[a-zA-Z_]\w*/,
-    _ident_special: $ => /[0-9]+|\^([A-Z[?\^_]|])|./,
+    // this pattern tries to encapsulate the joys of S_scan_ident in toke.c in perl core
+    // _dollar_ident_zw takes care of the subtleties that distinguish $$; ( only $$
+    // followed by semicolon ) from $$deref
+    _ident_special: $ => choice(/[0-9]+|\^([A-Z[?\^_]|])|./, seq('$', $._dollar_ident_zw) ),
 
     bareword: $ => prec.dynamic(1, $._bareword),
     // _bareword is at the very end b/c the lexer prefers tokens defined earlier in the grammar

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.4",
     "eslint-plugin-promise": "^6.0.0",
-    "tree-sitter-cli": "^0.20.6"
+    "tree-sitter-cli": "^0.20.8"
   },
   "tree-sitter": [
     {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -31,8 +31,6 @@
 
 (phaser_statement phase: _ @keyword.phaser)
 
-[ "[" "]" "{" "}" "(" ")" ] @punctuation.bracket
-
 [
   "or" "and"
   "eq" "ne" "cmp" "lt" "le" "ge" "gt"
@@ -102,7 +100,8 @@
   (varname)
   "}" @punctuation.special
 )
-; will dis werk?
+
+
 (
   (_
     (varname) @variable.builtin.name
@@ -129,4 +128,10 @@
 
 (
   [ "=>" "," ";" "->" ] @punctuation.delimiter
+)
+
+; ordering so both nvim + ts-cli are happy
+(
+  [ "[" "]" "{" "}" "(" ")" ] @punctuation.bracket
+  (#set! "priority" 90)
 )

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -97,6 +97,19 @@
 
 (ERROR) @error
 
+(_
+  "{" @punctuation.special
+  (varname)
+  "}" @punctuation.special
+)
+; will dis werk?
+(
+  (_
+    (varname) @variable.builtin.name
+   ) @variable.builtin
+  (#match? @variable.builtin.name "^((ENV|ARGV|INC|ARGVOUT|SIG|STDIN|STDOUT|STDERR)|[_+!@#$%^&*(){}<>;:'\"0-9-]|)$")
+)
+
 [(scalar) (arraylen)] @variable.scalar
 (scalar_deref_expression [ "$" "*"] @variable.scalar)
 (array) @variable.array

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -100,13 +100,17 @@
   (varname)
   "}" @punctuation.special
 )
+(varname 
+  (block
+    "{" @punctuation.special 
+    "}" @punctuation.special 
+  )
+)
 
 
 (
-  (_
-    (varname) @variable.builtin.name
-   ) @variable.builtin
-  (#match? @variable.builtin.name "^((ENV|ARGV|INC|ARGVOUT|SIG|STDIN|STDOUT|STDERR)|[_ab]|\\W|\\d+|\\^.*)$")
+  (varname) @variable.builtin
+  (#match? @variable.builtin "^((ENV|ARGV|INC|ARGVOUT|SIG|STDIN|STDOUT|STDERR)|[_ab]|\\W|\\d+|\\^.*)$")
 )
 
 [(scalar) (arraylen)] @variable.scalar
@@ -130,8 +134,8 @@
   [ "=>" "," ";" "->" ] @punctuation.delimiter
 )
 
-; ordering so both nvim + ts-cli are happy
 (
   [ "[" "]" "{" "}" "(" ")" ] @punctuation.bracket
+  ; priority hack so nvim + ts-cli behave the same
   (#set! "priority" 90)
 )

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -113,9 +113,9 @@
   (#match? @variable.builtin "^((ENV|ARGV|INC|ARGVOUT|SIG|STDIN|STDOUT|STDERR)|[_ab]|\\W|\\d+|\\^.*)$")
 )
 
-[(scalar) (arraylen)] @variable.scalar
+(scalar) @variable.scalar
 (scalar_deref_expression [ "$" "*"] @variable.scalar)
-(array) @variable.array
+[(array) (arraylen)] @variable.array
 (array_deref_expression [ "@" "*"] @variable.array)
 (hash) @variable.hash
 (hash_deref_expression [ "%" "*"] @variable.hash)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -107,7 +107,7 @@
   (_
     (varname) @variable.builtin.name
    ) @variable.builtin
-  (#match? @variable.builtin.name "^((ENV|ARGV|INC|ARGVOUT|SIG|STDIN|STDOUT|STDERR)|[_+!@#$%^&*(){}<>;:'\"0-9-]|)$")
+  (#match? @variable.builtin.name "^((ENV|ARGV|INC|ARGVOUT|SIG|STDIN|STDOUT|STDERR)|[_ab]|\\W|\\d+|\\^.*)$")
 )
 
 [(scalar) (arraylen)] @variable.scalar

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -48,6 +48,7 @@ enum TokenType {
   TOKEN_PERLY_COMMA_CONT,
   TOKEN_FAT_COMMA_ZW,
   TOKEN_BRACE_END_ZW,
+  TOKEN_DOLLAR_IDENT_ZW,
   /* zero-width high priority token */
   TOKEN_NONASSOC,
   /* error condition is always last */
@@ -427,6 +428,15 @@ bool tree_sitter_perl_external_scanner_scan(
   }
   if (lexer->eof(lexer))
     return false;
+
+  if(valid_symbols[TOKEN_DOLLAR_IDENT_ZW]) {
+    // false on word chars, another dollar or {
+    if (!isidcont(c) && !strchr("${:", c)) {
+      // TODO - handling ::
+      TOKEN(TOKEN_DOLLAR_IDENT_ZW);
+    }
+
+  }
 
   if(valid_symbols[TOKEN_APOSTROPHE] && c == '\'') {
     ADVANCE_C;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -431,8 +431,16 @@ bool tree_sitter_perl_external_scanner_scan(
 
   if(valid_symbols[TOKEN_DOLLAR_IDENT_ZW]) {
     // false on word chars, another dollar or {
-    if (!isidcont(c) && !strchr("${:", c)) {
-      // TODO - handling ::
+    if (!isidcont(c) && !strchr("${", c)) {
+      if (c == ':') {
+        lexer->mark_end(lexer);
+        ADVANCE_C;
+        if (c == ':') {
+          // we can safely bail out here b/c we know that $:: is handled in the grammar,
+          // and that's the only place we can ever get to this rule here
+          return false;
+        }
+      }
       TOKEN(TOKEN_DOLLAR_IDENT_ZW);
     }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -433,6 +433,8 @@ bool tree_sitter_perl_external_scanner_scan(
     // false on word chars, another dollar or {
     if (!isidcont(c) && !strchr("${", c)) {
       if (c == ':') {
+        // NOTE - it's a syntax error to do $$:, so that's why we return dollar_ident_zw in
+        // that case
         lexer->mark_end(lexer);
         ADVANCE_C;
         if (c == ':') {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -412,11 +412,6 @@ bool tree_sitter_perl_external_scanner_scan(
     TOKEN(TOKEN_CTRL_Z);
 
   if(valid_symbols[PERLY_SEMICOLON]) {
-    if(c == ';') {
-      ADVANCE_C;
-
-      TOKEN(PERLY_SEMICOLON);
-    }
     if(c == '}' || lexer->eof(lexer)) {
       // do a PERLY_SEMICOLON unless we're in brace autoquoting
       if(is_ERROR || !valid_symbols[TOKEN_BRACE_END_ZW]) {

--- a/test/corpus/autoquote
+++ b/test/corpus/autoquote
@@ -52,11 +52,13 @@ $hash{shift};
 (source_file
   (expression_statement
     (hash_element_expression
-      hash: (container_variable)
+      hash: (container_variable
+        (varname))
       key: (autoquoted_bareword)))
   (expression_statement
     (hash_element_expression
-      hash: (container_variable)
+      hash: (container_variable
+        (varname))
       key: (autoquoted_bareword))))
 
 ================================================================================
@@ -69,11 +71,13 @@ $hash{q};
 (source_file
   (expression_statement
     (hash_element_expression
-      hash: (container_variable)
+      hash: (container_variable
+        (varname))
       key: (string_literal)))
   (expression_statement
     (hash_element_expression
-      hash: (container_variable)
+      hash: (container_variable
+        (varname))
       key: (autoquoted_bareword))))
 
 ================================================================================
@@ -89,17 +93,23 @@ ${1};
 
 (source_file
   (expression_statement
-    (scalar))
+    (scalar
+      (varname)))
   (expression_statement
-    (scalar))
+    (scalar
+      (varname)))
   (expression_statement
-    (scalar))
+    (scalar
+      (varname)))
   (expression_statement
-    (scalar))
+    (scalar
+      (varname)))
   (expression_statement
-    (scalar))
+    (scalar
+      (varname)))
   (expression_statement
-    (scalar)))
+    (scalar
+      (varname))))
 
 ================================================================================
 autoquoting keywords

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -31,7 +31,8 @@ eval 'die $x';
 (source_file
   (expression_statement
     (eval_expression
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (eval_expression
       (string_literal))))
@@ -48,14 +49,16 @@ eval { die $x };
     (eval_expression
       (block
         (expression_statement
-          (scalar)))))
+          (scalar
+            (varname))))))
   (expression_statement
     (eval_expression
       (block
         (expression_statement
           (ambiguous_function_call_expression
             (function)
-            (scalar)))))))
+            (scalar
+              (varname))))))))
 
 ================================================================================
 Anonymous array
@@ -95,18 +98,21 @@ $var = 12, 34;
 (source_file
   (expression_statement
     (assignment_expression
-      (scalar)
+      (scalar
+        (varname))
       (number)))
   (expression_statement
     (assignment_expression
-      (scalar)
+      (scalar
+        (varname))
       (binary_expression
         (number)
         (number))))
   (expression_statement
     (list_expression
       (assignment_expression
-        (scalar)
+        (scalar
+          (varname))
         (number))
       (number))))
 
@@ -143,17 +149,20 @@ $hashref->@{qw/key1 key2/};
 (source_file
   (expression_statement
     (slice_expression
-      array: (slice_container_variable)
+      array: (slice_container_variable
+        (varname))
       (list_expression
         (number)
         (number))))
   (expression_statement
     (slice_expression
-      hash: (slice_container_variable)
+      hash: (slice_container_variable
+        (varname))
       (quoted_word_list)))
   (expression_statement
     (slice_expression
-      arrayref: (scalar)
+      arrayref: (scalar
+        (varname))
       (list_expression
         (number)
         (number))))
@@ -166,7 +175,8 @@ $hashref->@{qw/key1 key2/};
       (number)))
   (expression_statement
     (slice_expression
-      hashref: (scalar)
+      hashref: (scalar
+        (varname))
       (quoted_word_list))))
 
 ================================================================================
@@ -182,17 +192,20 @@ $hashref->%{qw/key1 key2/};
 (source_file
   (expression_statement
     (keyval_expression
-      array: (keyval_container_variable)
+      array: (keyval_container_variable
+        (varname))
       (list_expression
         (number)
         (number))))
   (expression_statement
     (keyval_expression
-      hash: (keyval_container_variable)
+      hash: (keyval_container_variable
+        (varname))
       (quoted_word_list)))
   (expression_statement
     (keyval_expression
-      arrayref: (scalar)
+      arrayref: (scalar
+        (varname))
       (list_expression
         (number)
         (number))))
@@ -205,7 +218,8 @@ $hashref->%{qw/key1 key2/};
       (number)))
   (expression_statement
     (keyval_expression
-      hashref: (scalar)
+      hashref: (scalar
+        (varname))
       (quoted_word_list))))
 
 ================================================================================
@@ -228,10 +242,13 @@ $sref->$*;
 (source_file
   (expression_statement
     (scalar
-      (scalar)))
+      (varname
+        (scalar
+          (varname)))))
   (expression_statement
     (scalar_deref_expression
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 Array deref
@@ -243,10 +260,13 @@ $aref->@*;
 (source_file
   (expression_statement
     (array
-      (scalar)))
+      (varname
+        (scalar
+          (varname)))))
   (expression_statement
     (array_deref_expression
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 Hash deref
@@ -258,10 +278,13 @@ $href->%*;
 (source_file
   (expression_statement
     (hash
-      (scalar)))
+      (varname
+        (scalar
+          (varname)))))
   (expression_statement
     (hash_deref_expression
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 Amper deref
@@ -272,7 +295,8 @@ $cref->&*;
 (source_file
   (expression_statement
     (amper_deref_expression
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 Glob deref
@@ -284,10 +308,13 @@ $gref->**;
 (source_file
   (expression_statement
     (glob
-      (scalar)))
+      (varname
+        (scalar
+          (varname)))))
   (expression_statement
     (glob_deref_expression
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 require EXPR
@@ -343,7 +370,8 @@ undef $var;
     (undef_expression))
   (expression_statement
     (undef_expression
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 local
@@ -357,22 +385,28 @@ local $SIG{INT} = sub { ... };
 (source_file
   (expression_statement
     (localization_expression
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (localization_expression
       (array_element_expression
-        (container_variable)
-        (scalar))))
+        (container_variable
+          (varname))
+        (scalar
+          (varname)))))
   (expression_statement
     (localization_expression
       (hash_element_expression
-        (container_variable)
-        (scalar))))
+        (container_variable
+          (varname))
+        (scalar
+          (varname)))))
   (expression_statement
     (assignment_expression
       (localization_expression
         (hash_element_expression
-          (container_variable)
+          (container_variable
+            (varname))
           (autoquoted_bareword)))
       (anonymous_subroutine_expression
         (block

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -44,7 +44,8 @@ $obj->meth;
 (source_file
   (expression_statement
     (method_call_expression
-      invocant: (scalar)
+      invocant: (scalar
+        (varname))
       method: (method))))
 
 ================================================================================
@@ -56,7 +57,8 @@ $obj->meth();
 (source_file
   (expression_statement
     (method_call_expression
-      invocant: (scalar)
+      invocant: (scalar
+        (varname))
       method: (method))))
 
 ================================================================================
@@ -68,7 +70,8 @@ $obj->meth(123);
 (source_file
   (expression_statement
     (method_call_expression
-      invocant: (scalar)
+      invocant: (scalar
+        (varname))
       method: (method)
       arguments: (number))))
 
@@ -81,7 +84,8 @@ $obj->meth(12, 34);
 (source_file
   (expression_statement
     (method_call_expression
-      invocant: (scalar)
+      invocant: (scalar
+        (varname))
       method: (method)
       arguments: (list_expression
         (number)
@@ -131,10 +135,12 @@ keys %hash;
 (source_file
   (expression_statement
     (func1op_call_expression
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (func1op_call_expression
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (func1op_call_expression))
   (expression_statement
@@ -142,15 +148,19 @@ keys %hash;
   (expression_statement
     (list_expression
       (func1op_call_expression
-        (scalar))
+        (scalar
+          (varname)))
       (func1op_call_expression
-        (scalar))))
+        (scalar
+          (varname)))))
   (expression_statement
     (func1op_call_expression
-      (array)))
+      (array
+        (varname))))
   (expression_statement
     (func1op_call_expression
-    (hash))))
+      (hash
+        (varname)))))
 
 ================================================================================
 Filetest operators
@@ -166,7 +176,8 @@ Filetest operators
       (interpolated_string_literal)))
   (expression_statement
     (func1op_call_expression
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (func1op_call_expression
       (bareword))))

--- a/test/corpus/heredocs
+++ b/test/corpus/heredocs
@@ -9,6 +9,7 @@ TINGS
 This type does no $interp
 RAW
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (function_call_expression
@@ -16,10 +17,17 @@ RAW
       (list_expression
         (heredoc_token)
         (string_literal))))
-  (heredoc_content (scalar) (escape_sequence) (escape_sequence) (heredoc_end))
-  (expression_statement (heredoc_token))
-  (heredoc_content (heredoc_end))
-)
+  (heredoc_content
+    (scalar
+      (varname))
+    (escape_sequence)
+    (escape_sequence)
+    (heredoc_end))
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (heredoc_end)))
+
 ================================================================================
 Quoted heredocs
 ================================================================================
@@ -31,12 +39,20 @@ you'd think this is just
 CRAZY, but you'd be \n $wrong
   CRAZY
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (heredoc_token))
-  (heredoc_content (scalar) (escape_sequence) (heredoc_end))
-  (expression_statement (heredoc_token))
-  (heredoc_content (heredoc_end))
-)
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (scalar
+      (varname))
+    (escape_sequence)
+    (heredoc_end))
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (heredoc_end)))
+
 ================================================================================
 Command heredocs
 ================================================================================
@@ -44,10 +60,13 @@ Command heredocs
 :(){ :|:& };:
 BASH
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (command_heredoc_token))
-  (heredoc_content (heredoc_end))
-)
+  (expression_statement
+    (command_heredoc_token))
+  (heredoc_content
+    (heredoc_end)))
+
 ================================================================================
 Indented heredocs
 ================================================================================
@@ -62,14 +81,23 @@ Indented heredocs
     And apparently, this $monstrosity works, too
     LOLWUT
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (heredoc_token))
-  (heredoc_content (heredoc_end))
-  (expression_statement (heredoc_token))
-  (heredoc_content (scalar) (heredoc_end))
-  (expression_statement (heredoc_token))
-  (heredoc_content (heredoc_end))
-)
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (heredoc_end))
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (scalar
+      (varname))
+    (heredoc_end))
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (heredoc_end)))
+
 ================================================================================
 Insane heredocs
 ================================================================================
@@ -80,12 +108,19 @@ WUT'\n?
  WHY?$CUZ
 WHY?$CUZ
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (heredoc_token))
-  (heredoc_content (heredoc_end))
-  (expression_statement (heredoc_token))
-  (heredoc_content (scalar) (heredoc_end))
-  )
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (heredoc_end))
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (scalar
+      (varname))
+    (heredoc_end)))
+
 ================================================================================
 heredocs after a statement (gh#92)
 ================================================================================
@@ -94,11 +129,17 @@ print <<EOF;
 $tings --tings
 EOF
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (variable_declaration (scalar)))
-  (expression_statement 
-    (ambiguous_function_call_expression (function) (heredoc_token)))
+  (expression_statement
+    (variable_declaration
+      (scalar
+        (varname))))
+  (expression_statement
+    (ambiguous_function_call_expression
+      (function)
+      (heredoc_token)))
   (heredoc_content
-   (scalar)
-   (heredoc_end))
-)
+    (scalar
+      (varname))
+    (heredoc_end)))

--- a/test/corpus/interpolation
+++ b/test/corpus/interpolation
@@ -9,22 +9,25 @@ Fancy indirob interpolation
   (expression_statement
     (interpolated_string_literal
       (scalar
-        (block
-          (expression_statement
-            (refgen_expression
-              (method_call_expression
-                (scalar)
-                (method))))))))
+        (varname
+          (block
+            (expression_statement
+              (refgen_expression
+                (method_call_expression
+                  (scalar
+                    (varname))
+                  (method)))))))))
   (expression_statement
     (interpolated_string_literal
       (array
-        (block
-          (expression_statement
-            (anonymous_array_expression
-              (list_expression
-                (number)
-                (number)
-                (number)))))))))
+        (varname
+          (block
+            (expression_statement
+              (anonymous_array_expression
+                (list_expression
+                  (number)
+                  (number)
+                  (number))))))))))
 
 ================================================================================
 Array element interpolation
@@ -38,18 +41,21 @@ Array element interpolation
   (expression_statement
     (interpolated_string_literal
       (array_element_expression
-        (container_variable)
+        (container_variable
+          (varname))
         (number))))
   (expression_statement
     (interpolated_string_literal
       (array_element_expression
-        (scalar)
+        (scalar
+          (varname))
         (number))))
   (expression_statement
     (interpolated_string_literal
       (array_element_expression
         (array_element_expression
-          (scalar)
+          (scalar
+            (varname))
           (number))
         (number)))))
 
@@ -65,18 +71,21 @@ Hash element interpolation
   (expression_statement
     (interpolated_string_literal
       (hash_element_expression
-        (container_variable)
+        (container_variable
+          (varname))
         (autoquoted_bareword))))
   (expression_statement
     (interpolated_string_literal
       (hash_element_expression
-        (scalar)
+        (scalar
+          (varname))
         (autoquoted_bareword))))
   (expression_statement
     (interpolated_string_literal
       (hash_element_expression
         (hash_element_expression
-          (scalar)
+          (scalar
+            (varname))
           (autoquoted_bareword))
         (autoquoted_bareword)))))
 
@@ -91,13 +100,16 @@ Space skips interpolation
 (source_file
   (expression_statement
     (interpolated_string_literal
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (interpolated_string_literal
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (interpolated_string_literal
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 Slice interpolation
@@ -111,23 +123,27 @@ Slice interpolation
   (expression_statement
     (interpolated_string_literal
       (slice_expression
-        array: (slice_container_variable)
+        array: (slice_container_variable
+          (varname))
         (list_expression
           (number)
           (number)))))
   (expression_statement
     (interpolated_string_literal
       (slice_expression
-        hash: (slice_container_variable)
+        hash: (slice_container_variable
+          (varname))
         (bareword))))
   (expression_statement
     (interpolated_string_literal
       (slice_expression
-        arrayref: (scalar)
+        arrayref: (scalar
+          (varname))
         (list_expression
           (number)
           (number)
           (number))))))
+
 ================================================================================
 Punctuation vars that interpolate
 ================================================================================
@@ -140,15 +156,26 @@ Punctuation vars that interpolate
 
 (source_file
   (expression_statement
-    (interpolated_string_literal (scalar)))
+    (interpolated_string_literal
+      (scalar
+        (varname))))
   (expression_statement
-    (interpolated_string_literal (scalar)))
+    (interpolated_string_literal
+      (scalar
+        (varname))))
   (expression_statement
-    (interpolated_string_literal (scalar)))
+    (interpolated_string_literal
+      (scalar
+        (varname))))
   (expression_statement
-    (interpolated_string_literal (array)))
+    (interpolated_string_literal
+      (array
+        (varname))))
   (expression_statement
-    (interpolated_string_literal (array))))
+    (interpolated_string_literal
+      (array
+        (varname)))))
+
 ================================================================================
 Punctuation vars that do not interpolate
 ================================================================================

--- a/test/corpus/literals
+++ b/test/corpus/literals
@@ -164,15 +164,18 @@ qq'with $scalar in single-quotes';
 (source_file
   (expression_statement
     (interpolated_string_literal
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (interpolated_string_literal))
   (expression_statement
     (interpolated_string_literal
-      (array)))
+      (array
+        (varname))))
   (expression_statement
     (interpolated_string_literal
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 qw() lists
@@ -222,7 +225,8 @@ qw\ backslashes \;
     (command_string))
   (expression_statement
     (command_string
-      (scalar))))
+      (scalar
+        (varname)))))
 
 ================================================================================
 qx() strings
@@ -240,6 +244,7 @@ qx'command with no $interpolation';
     (command_string))
   (expression_statement
     (command_string
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (command_string)))

--- a/test/corpus/map-grep
+++ b/test/corpus/map-grep
@@ -16,9 +16,11 @@ map { lc($_) => 1 } @array;        # and this.
             (unary_expression
               (interpolated_string_literal
                 (escape_sequence)
-                (scalar)))
+                (scalar
+                  (varname))))
             (number))))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (expression_statement
     (map_grep_expression
@@ -27,9 +29,11 @@ map { lc($_) => 1 } @array;        # and this.
           (list_expression
             (interpolated_string_literal
               (escape_sequence)
-              (scalar))
+              (scalar
+                (varname)))
             (number))))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (expression_statement
     (map_grep_expression
@@ -38,9 +42,11 @@ map { lc($_) => 1 } @array;        # and this.
           (list_expression
             (interpolated_string_literal
               (escape_sequence)
-              (scalar))
+              (scalar
+                (varname)))
             (number))))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (expression_statement
     (map_grep_expression
@@ -48,9 +54,11 @@ map { lc($_) => 1 } @array;        # and this.
         (expression_statement
           (list_expression
             (func1op_call_expression
-              (scalar))
+              (scalar
+                (varname)))
             (number))))
-      (array)))
+      (array
+        (varname))))
   (comment))
 
 ================================================================================
@@ -68,9 +76,11 @@ map { "\L$_"   => 1 }, @array;     # perl guesses EXPR; SURPRISE!
       (unary_expression
         (list_expression
           (func1op_call_expression
-            (scalar))
+            (scalar
+              (varname)))
           (number)))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (expression_statement
     (map_grep_expression
@@ -78,18 +88,22 @@ map { "\L$_"   => 1 }, @array;     # perl guesses EXPR; SURPRISE!
         (anonymous_hash_expression
           (list_expression
             (func1op_call_expression
-              (scalar))
+              (scalar
+                (varname)))
             (number))))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (expression_statement
     (map_grep_expression
       (anonymous_hash_expression
         (interpolated_string_literal
           (escape_sequence)
-          (scalar))
+          (scalar
+            (varname)))
         (number))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (comment))
 
@@ -105,12 +119,15 @@ map - goshdarn parens
   (expression_statement
     (list_expression
       (assignment_expression
-        (hash)
+        (hash
+          (varname))
         (map_grep_expression
           (func1op_call_expression
-            (scalar))
+            (scalar
+              (varname)))
           (number)))
-      (array)))
+      (array
+        (varname))))
   (comment)
   (comment)
   (comment))
@@ -131,7 +148,8 @@ map +(lc($_) => 1 ), (1, 2), 3;
         (expression_statement
           (list_expression
             (func1op_call_expression
-              (scalar))
+              (scalar
+                (varname)))
             (number))))
       list: (number)
       list: (number)
@@ -141,7 +159,8 @@ map +(lc($_) => 1 ), (1, 2), 3;
       callback: (unary_expression
         operand: (list_expression
           (func1op_call_expression
-            (scalar))
+            (scalar
+              (varname)))
           (number)))
       list: (number)
       list: (number)
@@ -152,7 +171,8 @@ map +(lc($_) => 1 ), (1, 2), 3;
         (expression_statement
           (list_expression
             (func1op_call_expression
-              (scalar))
+              (scalar
+                (varname)))
             (number))))
       list: (list_expression
         (number)
@@ -163,7 +183,8 @@ map +(lc($_) => 1 ), (1, 2), 3;
       callback: (unary_expression
         operand: (list_expression
           (func1op_call_expression
-            (scalar))
+            (scalar
+              (varname)))
           (number)))
       list: (list_expression
         (number)

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -5,7 +5,11 @@ EXPR or EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (lowprec_logical_expression (number) (number))))
+  (expression_statement
+    (lowprec_logical_expression
+      (number)
+      (number))))
+
 ================================================================================
 EXPR and EXPR
 ================================================================================
@@ -13,7 +17,11 @@ EXPR and EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (lowprec_logical_expression (number) (number))))
+  (expression_statement
+    (lowprec_logical_expression
+      (number)
+      (number))))
+
 ================================================================================
 EXPR, EXPR
 ================================================================================
@@ -24,10 +32,23 @@ EXPR, EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (list_expression (number) (number) (number)))
-  (expression_statement (list_expression (number) (number)))
-  (expression_statement (list_expression (number) (number)))
-  (expression_statement (list_expression (number) (number))))
+  (expression_statement
+    (list_expression
+      (number)
+      (number)
+      (number)))
+  (expression_statement
+    (list_expression
+      (number)
+      (number)))
+  (expression_statement
+    (list_expression
+      (number)
+      (number)))
+  (expression_statement
+    (list_expression
+      (number)
+      (number))))
 
 ================================================================================
 EXPR || EXPR
@@ -38,9 +59,19 @@ EXPR || EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (binary_expression (number) (number)))
-  (expression_statement (binary_expression (number) (number)))
-  (expression_statement (binary_expression (number) (number))))
+  (expression_statement
+    (binary_expression
+      (number)
+      (number)))
+  (expression_statement
+    (binary_expression
+      (number)
+      (number)))
+  (expression_statement
+    (binary_expression
+      (number)
+      (number))))
+
 ================================================================================
 EXPR eq EXPR
 ================================================================================
@@ -49,8 +80,15 @@ EXPR eq EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (equality_expression (number) (number)))
-  (expression_statement (equality_expression (number) (number))))
+  (expression_statement
+    (equality_expression
+      (number)
+      (number)))
+  (expression_statement
+    (equality_expression
+      (number)
+      (number))))
+
 ================================================================================
 EXPR eq EXPR - list/non assoc
 ================================================================================
@@ -60,11 +98,24 @@ EXPR eq EXPR - list/non assoc
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (equality_expression (number) (number) (number)))
-  (expression_statement (equality_expression (number) (number) (number) (number)))
-  (expression_statement (equality_expression (number) (number)))
-  (ERROR (number))
-  )
+  (expression_statement
+    (equality_expression
+      (number)
+      (number)
+      (number)))
+  (expression_statement
+    (equality_expression
+      (number)
+      (number)
+      (number)
+      (number)))
+  (expression_statement
+    (equality_expression
+      (number)
+      (number)))
+  (ERROR
+    (number)))
+
 ================================================================================
 EXPR < EXPR
 ================================================================================
@@ -76,11 +127,27 @@ EXPR < EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (relational_expression (number) (number)))
-  (expression_statement (relational_expression (number) (number)))
-  (expression_statement (relational_expression (number) (number)))
-  (expression_statement (relational_expression (number) (number)))
-  (expression_statement (relational_expression (number) (number))))
+  (expression_statement
+    (relational_expression
+      (number)
+      (number)))
+  (expression_statement
+    (relational_expression
+      (number)
+      (number)))
+  (expression_statement
+    (relational_expression
+      (number)
+      (number)))
+  (expression_statement
+    (relational_expression
+      (number)
+      (number)))
+  (expression_statement
+    (relational_expression
+      (number)
+      (number))))
+
 ================================================================================
 EXPR < EXPR - list/non assoc
 ================================================================================
@@ -89,22 +156,55 @@ EXPR < EXPR - list/non assoc
 (12 < 34) > 45;
 12 > (34 < 45);
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (relational_expression (number) (number) (number) (number)))
-  (expression_statement (relational_expression (number) (number))) (ERROR (number))
-  (expression_statement (relational_expression (relational_expression (number) (number)) (number)))
-  (expression_statement (relational_expression (number) (relational_expression (number) (number))))
-)
+  (expression_statement
+    (relational_expression
+      (number)
+      (number)
+      (number)
+      (number)))
+  (expression_statement
+    (relational_expression
+      (number)
+      (number)))
+  (ERROR
+    (number))
+  (expression_statement
+    (relational_expression
+      (relational_expression
+        (number)
+        (number))
+      (number)))
+  (expression_statement
+    (relational_expression
+      (number)
+      (relational_expression
+        (number)
+        (number)))))
+
 ================================================================================
 < and eq - list/non assoc corner cases
 ================================================================================
 '' eq 2 > 3 > 4;
 1 > 2 <=> 3;
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (equality_expression (string_literal) (relational_expression (number) (number) (number))))
-  (expression_statement (equality_expression (relational_expression (number) (number)) (number) ))
-)
+  (expression_statement
+    (equality_expression
+      (string_literal)
+      (relational_expression
+        (number)
+        (number)
+        (number))))
+  (expression_statement
+    (equality_expression
+      (relational_expression
+        (number)
+        (number))
+      (number))))
+
 ================================================================================
 EXPR << EXPR
 ================================================================================
@@ -112,7 +212,11 @@ EXPR << EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (binary_expression left: (number) right: (number))))
+  (expression_statement
+    (binary_expression
+      left: (number)
+      right: (number))))
+
 ================================================================================
 EXPR + EXPR
 ================================================================================
@@ -120,7 +224,11 @@ EXPR + EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (binary_expression left: (number) right: (number))))
+  (expression_statement
+    (binary_expression
+      left: (number)
+      right: (number))))
+
 ================================================================================
 EXPR * EXPR
 ================================================================================
@@ -128,7 +236,11 @@ EXPR * EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (binary_expression left: (number) right: (number))))
+  (expression_statement
+    (binary_expression
+      left: (number)
+      right: (number))))
+
 ================================================================================
 EXPR =~ EXPR
 ================================================================================
@@ -136,7 +248,13 @@ $str =~ $re;
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (binary_expression left: (scalar) right: (scalar))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (scalar
+        (varname)))))
+
 ================================================================================
 EXPR ** EXPR
 ================================================================================
@@ -144,7 +262,11 @@ EXPR ** EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (binary_expression left: (number) right: (number))))
+  (expression_statement
+    (binary_expression
+      left: (number)
+      right: (number))))
+
 ================================================================================
 (EXPR)
 ================================================================================
@@ -155,7 +277,10 @@ EXPR ** EXPR
   (expression_statement
     (binary_expression
       left: (number)
-      right: (binary_expression left: (number) right: (number)))))
+      right: (binary_expression
+        left: (number)
+        right: (number)))))
+
 ================================================================================
 !EXPR
 ================================================================================
@@ -163,7 +288,10 @@ EXPR ** EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (unary_expression operand: (number))))
+  (expression_statement
+    (unary_expression
+      operand: (number))))
+
 ================================================================================
 EXPR ? EXPR : EXPR
 ================================================================================
@@ -181,11 +309,11 @@ EXPR ? EXPR : EXPR
     (conditional_expression
       condition: (number)
       consequent: (number)
-      alternative:
-        (conditional_expression
-          condition: (number)
-          consequent: (number)
-          alternative: (number)))))
+      alternative: (conditional_expression
+        condition: (number)
+        consequent: (number)
+        alternative: (number)))))
+
 ================================================================================
 ++EXPR
 ================================================================================
@@ -194,8 +322,15 @@ EXPR ? EXPR : EXPR
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (preinc_expression (scalar)))
-  (expression_statement (preinc_expression (scalar))))
+  (expression_statement
+    (preinc_expression
+      (scalar
+        (varname))))
+  (expression_statement
+    (preinc_expression
+      (scalar
+        (varname)))))
+
 ================================================================================
 EXPR++
 ================================================================================
@@ -204,8 +339,15 @@ $var--;
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (postinc_expression (scalar)))
-  (expression_statement (postinc_expression (scalar))))
+  (expression_statement
+    (postinc_expression
+      (scalar
+        (varname))))
+  (expression_statement
+    (postinc_expression
+      (scalar
+        (varname)))))
+
 ================================================================================
 \EXPR
 ================================================================================
@@ -213,7 +355,9 @@ $var--;
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (refgen_expression (number))))
+  (expression_statement
+    (refgen_expression
+      (number))))
 
 ================================================================================
 range ops
@@ -222,16 +366,33 @@ range ops
 13 ... 14;
 13 .. (1 .. 4);
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (binary_expression (number) (number)))
-  (expression_statement (binary_expression (number) (number)))
-  (expression_statement (binary_expression (number) (binary_expression (number) (number))))
-  )
+  (expression_statement
+    (binary_expression
+      (number)
+      (number)))
+  (expression_statement
+    (binary_expression
+      (number)
+      (number)))
+  (expression_statement
+    (binary_expression
+      (number)
+      (binary_expression
+        (number)
+        (number)))))
+
 ================================================================================
 range ops - nonassoc
 ================================================================================
 1 .. 2 .. 3;
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (binary_expression (number) (number))) (ERROR (number))
-)
+  (expression_statement
+    (binary_expression
+      (number)
+      (number)))
+  (ERROR
+    (number)))

--- a/test/corpus/pod
+++ b/test/corpus/pod
@@ -14,22 +14,31 @@ Foo
 
 5678;
 --------------------------------------------------------------------------------
+
 (source_file
   (pod)
-  (expression_statement (number))
+  (expression_statement
+    (number))
   (pod)
-  (expression_statement (number)))
+  (expression_statement
+    (number)))
+
 ================================================================================
 not confused by leading whitespace
 ================================================================================
 my $x
   =head1() ;
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (assignment_expression
-      (variable_declaration (scalar))
-      (function_call_expression (function)))))
+      (variable_declaration
+        (scalar
+          (varname)))
+      (function_call_expression
+        (function)))))
+
 ================================================================================
 POD can appear anywhere within an expression
 ================================================================================
@@ -42,8 +51,14 @@ my $total =
 
   2;
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (assignment_expression
-      (variable_declaration (scalar))
-      (binary_expression (number) (pod) (number)))))
+      (variable_declaration
+        (scalar
+          (varname)))
+      (binary_expression
+        (number)
+        (pod)
+        (number)))))

--- a/test/corpus/regexp
+++ b/test/corpus/regexp
@@ -10,13 +10,22 @@ qr/^anchored pattern$/;
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (quoted_regexp))
-  (expression_statement (quoted_regexp))
-  (expression_statement (quoted_regexp (scalar)))
-  (expression_statement (quoted_regexp))
-  (expression_statement (quoted_regexp (quoted_regexp_modifiers)))
-  (expression_statement (quoted_regexp))
-  )
+  (expression_statement
+    (quoted_regexp))
+  (expression_statement
+    (quoted_regexp))
+  (expression_statement
+    (quoted_regexp
+      (scalar
+        (varname))))
+  (expression_statement
+    (quoted_regexp))
+  (expression_statement
+    (quoted_regexp
+      (quoted_regexp_modifiers)))
+  (expression_statement
+    (quoted_regexp)))
+
 ================================================================================
 Regexp match
 ================================================================================
@@ -30,11 +39,20 @@ m/^pattern(?:$|,)/;
 --------------------------------------------------------------------------------
 
 (source_file
-  (expression_statement (match_regexp))
-  (expression_statement (match_regexp))
-  (expression_statement (match_regexp (scalar)))
-  (expression_statement (match_regexp))
-  (expression_statement (match_regexp (match_regexp_modifiers)))
-  (expression_statement (match_regexp))
-  (expression_statement (match_regexp))
-  )
+  (expression_statement
+    (match_regexp))
+  (expression_statement
+    (match_regexp))
+  (expression_statement
+    (match_regexp
+      (scalar
+        (varname))))
+  (expression_statement
+    (match_regexp))
+  (expression_statement
+    (match_regexp
+      (match_regexp_modifiers)))
+  (expression_statement
+    (match_regexp))
+  (expression_statement
+    (match_regexp)))

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -246,7 +246,8 @@ foreach $V (1, 2, 3) { 456; }
 
 (source_file
   (for_statement
-    (scalar)
+    (scalar
+      (varname))
     (list_expression
       (number)
       (number)
@@ -255,7 +256,8 @@ foreach $V (1, 2, 3) { 456; }
       (expression_statement
         (number))))
   (for_statement
-    (scalar)
+    (scalar
+      (varname))
     (list_expression
       (number)
       (number)
@@ -275,7 +277,8 @@ foreach state $x (1, 2, 3) { 456; }
 
 (source_file
   (for_statement
-    my_var: (scalar)
+    my_var: (scalar
+      (varname))
     list: (list_expression
       (number)
       (number)
@@ -284,7 +287,8 @@ foreach state $x (1, 2, 3) { 456; }
       (expression_statement
         (number))))
   (for_statement
-    my_var: (scalar)
+    my_var: (scalar
+      (varname))
     list: (list_expression
       (number)
       (number)
@@ -293,7 +297,8 @@ foreach state $x (1, 2, 3) { 456; }
       (expression_statement
         (number))))
   (for_statement
-    var: (scalar)
+    var: (scalar
+      (varname))
     list: (list_expression
       (number)
       (number)
@@ -302,7 +307,8 @@ foreach state $x (1, 2, 3) { 456; }
       (expression_statement
         (number))))
   (for_statement
-    state_var: (scalar)
+    state_var: (scalar
+      (varname))
     list: (list_expression
       (number)
       (number)
@@ -319,9 +325,12 @@ foreach my ($k, $v) (%hash) { 456; }
 
 (source_file
   (for_statement
-    (scalar)
-    (scalar)
-    (hash)
+    (scalar
+      (varname))
+    (scalar
+      (varname))
+    (hash
+      (varname))
     (block
       (expression_statement
         (number)))))
@@ -336,13 +345,16 @@ for (my $i = 0; $i < 10; $i++) { 123; }
   (cstyle_for_statement
     initialiser: (assignment_expression
       left: (variable_declaration
-        variable: (scalar))
+        variable: (scalar
+          (varname)))
       right: (number))
     condition: (relational_expression
-      arg: (scalar)
+      arg: (scalar
+        (varname))
       arg: (number))
     iterator: (postinc_expression
-      operand: (scalar))
+      operand: (scalar
+        (varname)))
     (block
       (expression_statement
         (number)))))
@@ -394,12 +406,14 @@ ITEM: while(@items) { }
   (statement_label
     label: (identifier)
     statement: (for_statement
-      list: (array)
+      list: (array
+        (varname))
       block: (block)))
   (statement_label
     label: (identifier)
     statement: (loop_statement
-      condition: (array)
+      condition: (array
+        (varname))
       block: (block))))
 
 ================================================================================

--- a/test/corpus/subroutines
+++ b/test/corpus/subroutines
@@ -6,21 +6,28 @@ sub foo
   123;
 }
 --------------------------------------------------------------------------------
+
 (source_file
   (subroutine_declaration_statement
     name: (bareword)
     body: (block
-      (expression_statement (number)))))
+      (expression_statement
+        (number)))))
+
 ================================================================================
 Small anonymous
 ================================================================================
 sub { $x };
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (anonymous_subroutine_expression
       (block
-        (expression_statement (scalar))))))
+        (expression_statement
+          (scalar
+            (varname)))))))
+
 ================================================================================
 Attributes on named subs
 ================================================================================
@@ -29,22 +36,34 @@ sub def :lvalue const { }
 sub ghi :lvalue :const { }
 sub jkl : { }
 --------------------------------------------------------------------------------
+
 (source_file
   (subroutine_declaration_statement
     (bareword)
-    (attrlist (attribute (attribute_name)))
+    (attrlist
+      (attribute
+        (attribute_name)))
     (block))
   (subroutine_declaration_statement
     (bareword)
-    (attrlist (attribute (attribute_name)) (attribute (attribute_name)))
+    (attrlist
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name)))
     (block))
   (subroutine_declaration_statement
     (bareword)
-    (attrlist (attribute (attribute_name)) (attribute (attribute_name)))
+    (attrlist
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name)))
     (block))
   (subroutine_declaration_statement
     (bareword)
     (block)))
+
 ================================================================================
 Attributes on anonymous subs
 ================================================================================
@@ -53,19 +72,34 @@ sub :lvalue const {};
 sub :lvalue :const {};
 sub : {};
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (anonymous_subroutine_expression
-      (attrlist (attribute (attribute_name))) (block)))
+      (attrlist
+        (attribute
+          (attribute_name)))
+      (block)))
   (expression_statement
     (anonymous_subroutine_expression
-      (attrlist (attribute (attribute_name)) (attribute (attribute_name))) (block)))
+      (attrlist
+        (attribute
+          (attribute_name))
+        (attribute
+          (attribute_name)))
+      (block)))
   (expression_statement
     (anonymous_subroutine_expression
-      (attrlist (attribute (attribute_name)) (attribute (attribute_name))) (block)))
+      (attrlist
+        (attribute
+          (attribute_name))
+        (attribute
+          (attribute_name)))
+      (block)))
   (expression_statement
     (anonymous_subroutine_expression
       (block))))
+
 ================================================================================
 Attributes with values
 ================================================================================
@@ -75,23 +109,37 @@ sub ghi :title(Boo\(is fine) { }
 
 sub :title(Boo!) { }
 --------------------------------------------------------------------------------
+
 (source_file
   (subroutine_declaration_statement
     (bareword)
-    (attrlist (attribute (attribute_name) (attribute_value)))
+    (attrlist
+      (attribute
+        (attribute_name)
+        (attribute_value)))
     (block))
   (subroutine_declaration_statement
     (bareword)
-    (attrlist (attribute (attribute_name) (attribute_value)))
+    (attrlist
+      (attribute
+        (attribute_name)
+        (attribute_value)))
     (block))
   (subroutine_declaration_statement
     (bareword)
-    (attrlist (attribute (attribute_name) (attribute_value)))
+    (attrlist
+      (attribute
+        (attribute_name)
+        (attribute_value)))
     (block))
   (expression_statement
     (anonymous_subroutine_expression
-      (attrlist (attribute (attribute_name) (attribute_value)))
+      (attrlist
+        (attribute
+          (attribute_name)
+          (attribute_value)))
       (block))))
+
 ================================================================================
 Prototypes or Signatures
 ================================================================================
@@ -103,18 +151,39 @@ sub bar1 ($arg) { }
 sub bar3 ($one = 1, $two = 2, $three = ($one + $two)) { }
 sub barN ($x, $y, @z) { }
 --------------------------------------------------------------------------------
+
 (source_file
-  (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
-  (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
-  (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
-  (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
-  (subroutine_declaration_statement (bareword) (prototype_or_signature) (block))
-  (subroutine_declaration_statement (bareword) (prototype_or_signature) (block)))
+  (subroutine_declaration_statement
+    (bareword)
+    (prototype_or_signature)
+    (block))
+  (subroutine_declaration_statement
+    (bareword)
+    (prototype_or_signature)
+    (block))
+  (subroutine_declaration_statement
+    (bareword)
+    (prototype_or_signature)
+    (block))
+  (subroutine_declaration_statement
+    (bareword)
+    (prototype_or_signature)
+    (block))
+  (subroutine_declaration_statement
+    (bareword)
+    (prototype_or_signature)
+    (block))
+  (subroutine_declaration_statement
+    (bareword)
+    (prototype_or_signature)
+    (block)))
+
 ================================================================================
 Attribute plus signature
 ================================================================================
 sub f :attr ($sig) {}
 --------------------------------------------------------------------------------
+
 (source_file
   (subroutine_declaration_statement
     (bareword)

--- a/test/corpus/variables
+++ b/test/corpus/variables
@@ -257,8 +257,6 @@ $!;
 $^_;
 ${^_arbitrary_VAR};
 ${^Foo};
-$$;
-1
 --------------------------------------------------------------------------------
 
 (source_file
@@ -280,12 +278,29 @@ $$;
   (expression_statement
     (scalar
       (varname)))
+)
+================================================================================
+Double dollar edge cases
+================================================================================
+$$;
+# symbols are invalid names
+$$:;
+$$';
+$[;
+--------------------------------------------------------------------------------
+(source_file
   (expression_statement
-    (scalar
-      (varname)))
+    (scalar (varname)))
+  (comment)
   (expression_statement
-    (number)))
-
+    (scalar (varname)))
+  (ERROR)
+  (expression_statement
+    (scalar (varname)))
+  (ERROR (UNEXPECTED '''))
+  (expression_statement
+    (scalar (varname)))
+)
 ================================================================================
 crazy vars
 ================================================================================

--- a/test/corpus/variables
+++ b/test/corpus/variables
@@ -8,21 +8,41 @@ $#a;
 %h;
 *g;
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (scalar))
-  (expression_statement (scalar))
-  (expression_statement (array))
-  (expression_statement (arraylen))
-  (expression_statement (hash))
-  (expression_statement (glob)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (array
+      (varname)))
+  (expression_statement
+    (arraylen
+      (varname)))
+  (expression_statement
+    (hash
+      (varname)))
+  (expression_statement
+    (glob
+      (varname))))
+
 ================================================================================
 vars in expressions
 ================================================================================
 $one + $two;
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
-    (binary_expression (scalar) (scalar))))
+    (binary_expression
+      (scalar
+        (varname))
+      (scalar
+        (varname)))))
+
 ================================================================================
 variable declarations
 ================================================================================
@@ -32,20 +52,48 @@ my %h;
 my ($S, @A, %h);
 our $PackageVar;
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (variable_declaration (scalar)))
-  (expression_statement (variable_declaration (array)))
-  (expression_statement (variable_declaration (hash)))
-  (expression_statement (variable_declaration (scalar) (array) (hash)))
-  (expression_statement (variable_declaration (scalar)))
-)
+  (expression_statement
+    (variable_declaration
+      (scalar
+        (varname))))
+  (expression_statement
+    (variable_declaration
+      (array
+        (varname))))
+  (expression_statement
+    (variable_declaration
+      (hash
+        (varname))))
+  (expression_statement
+    (variable_declaration
+      (scalar
+        (varname))
+      (array
+        (varname))
+      (hash
+        (varname))))
+  (expression_statement
+    (variable_declaration
+      (scalar
+        (varname)))))
+
 ================================================================================
 variable declarations including undef
 ================================================================================
 my ($x, undef, $z);
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (variable_declaration (scalar) (undef_expression) (scalar))))
+  (expression_statement
+    (variable_declaration
+      (scalar
+        (varname))
+      (undef_expression)
+      (scalar
+        (varname)))))
+
 ================================================================================
 variable declarations with initialiser
 ================================================================================
@@ -53,13 +101,31 @@ my $s = 123;
 my @a = (4, 5);
 my %h = (6, 7);
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
-    (assignment_expression (variable_declaration (scalar)) (number)))
+    (assignment_expression
+      (variable_declaration
+        (scalar
+          (varname)))
+      (number)))
   (expression_statement
-    (assignment_expression (variable_declaration (array)) (list_expression (number) (number))))
+    (assignment_expression
+      (variable_declaration
+        (array
+          (varname)))
+      (list_expression
+        (number)
+        (number))))
   (expression_statement
-    (assignment_expression (variable_declaration (hash)) (list_expression (number) (number)))))
+    (assignment_expression
+      (variable_declaration
+        (hash
+          (varname)))
+      (list_expression
+        (number)
+        (number)))))
+
 ================================================================================
 variable declarations with attributes
 ================================================================================
@@ -67,13 +133,35 @@ my $s :shared;
 my @a :lock;
 my ($S, @A, %h) :MyAttr(foo);
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
-    (variable_declaration (scalar) (attrlist (attribute (attribute_name)))))
+    (variable_declaration
+      (scalar
+        (varname))
+      (attrlist
+        (attribute
+          (attribute_name)))))
   (expression_statement
-    (variable_declaration (array) (attrlist (attribute (attribute_name)))))
+    (variable_declaration
+      (array
+        (varname))
+      (attrlist
+        (attribute
+          (attribute_name)))))
   (expression_statement
-    (variable_declaration (scalar) (array) (hash) (attrlist (attribute (attribute_name) (attribute_value))))))
+    (variable_declaration
+      (scalar
+        (varname))
+      (array
+        (varname))
+      (hash
+        (varname))
+      (attrlist
+        (attribute
+          (attribute_name)
+          (attribute_value))))))
+
 ================================================================================
 array elements
 ================================================================================
@@ -81,23 +169,28 @@ $a[123];
 $aref->[123];
 $a[1][2][3];
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (array_element_expression
-      array: (container_variable)
+      array: (container_variable
+        (varname))
       index: (number)))
   (expression_statement
     (array_element_expression
-      (scalar)
+      (scalar
+        (varname))
       index: (number)))
   (expression_statement
     (array_element_expression
       (array_element_expression
         (array_element_expression
-          array: (container_variable)
+          array: (container_variable
+            (varname))
           index: (number))
         index: (number))
       index: (number))))
+
 ================================================================================
 hash elements
 ================================================================================
@@ -105,23 +198,28 @@ $h{123};
 $href->{123};
 $h{1}{2}{3};
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (hash_element_expression
-      hash: (container_variable)
+      hash: (container_variable
+        (varname))
       key: (number)))
   (expression_statement
     (hash_element_expression
-      (scalar)
+      (scalar
+        (varname))
       key: (number)))
   (expression_statement
     (hash_element_expression
       (hash_element_expression
         (hash_element_expression
-          hash: (container_variable)
+          hash: (container_variable
+            (varname))
           key: (number))
         key: (number))
       key: (number))))
+
 ================================================================================
 coderef calls
 ================================================================================
@@ -129,33 +227,65 @@ $code->();
 $code->('args');
 $code->('args')(1)("and again")
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (coderef_call_expression
-      (scalar)))
+      (scalar
+        (varname))))
   (expression_statement
     (coderef_call_expression
-      (scalar)
+      (scalar
+        (varname))
       (string_literal)))
   (expression_statement
     (coderef_call_expression
       (coderef_call_expression
         (coderef_call_expression
-          (scalar)
+          (scalar
+            (varname))
           (string_literal))
         (number))
       (interpolated_string_literal))))
+
 ================================================================================
 special vars
 ================================================================================
 $1;
 $^X;
 $!;
+$^_;
+${^_arbitrary_VAR};
+${^Foo};
+$$;
+1
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (scalar))
-  (expression_statement (scalar))
-  (expression_statement (scalar)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (number)))
+
 ================================================================================
 crazy vars
 ================================================================================
@@ -163,18 +293,27 @@ $::application;
 $::::var;
 %overload::;
 --------------------------------------------------------------------------------
+
 (source_file
-  (expression_statement (scalar))
-  (expression_statement (scalar))
-  (expression_statement (hash))
-)
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (scalar
+      (varname)))
+  (expression_statement
+    (hash
+      (varname))))
+
 ================================================================================
 hash parsing precedence
 ================================================================================
 random_function %hash;
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
-   (ambiguous_function_call_expression
-     (function)
-     (hash))))
+    (ambiguous_function_call_expression
+      (function)
+      (hash
+        (varname)))))

--- a/test/highlight/variables.pm
+++ b/test/highlight/variables.pm
@@ -91,3 +91,7 @@ ${ ^ANY_IDENT1 };
 # ^^^^^^ variable.scalar
 $#array;
 #<- variable.scalar
+${+shift};
+#^ punctuation.special
+#    ^ function.builtin
+#       ^ punctuation.special

--- a/test/highlight/variables.pm
+++ b/test/highlight/variables.pm
@@ -3,7 +3,7 @@ $s; @a; %h;
 #   ^ variable.array
 #       ^ variable.hash
 $#arrlen;
-# <- variable.scalar
+# <- variable.array
 $one + $two;
 # <- variable.scalar
 #      ^ variable.scalar
@@ -88,9 +88,7 @@ $!;
 my $not::allowed;
 #       ^ error
 ${ ^ANY_IDENT1 };
-# ^^^^^^ variable.scalar
-$#array;
-#<- variable.scalar
+#  ^^^^^ variable.builtin
 ${+shift};
 #^ punctuation.special
 #    ^ function.builtin


### PR DESCRIPTION
- feat: expose the varname and work on the highlights
- chore: update all tests for new visible varname node
- feat: highlight those builtins!
- fix: parse the caret variables correctly
- fix: parse `$$` vs `$$thing` correctly 
