### PR TITLE
fix: whitespace in autoquoting

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -401,7 +401,8 @@ module.exports = grammar({
       $.map_grep_expression,
       /* PMFUNC */
       $.bareword,
-      $._autoquoted_bareword,
+      $.autoquoted_bareword,
+      $._fat_comma_autoquoted_bareword,
       $._listop,
 
       /* perly.y doesn't know about `my` because that is handled weirdly in
@@ -983,14 +984,16 @@ module.exports = grammar({
     _quotelikes: $ => choice('q', 'qq', 'qw', 'qx', 's', 'tr', 'y'),
     _autoquotables: $ => choice($._func0op, $._func1op, $._keywords, $._quotelikes),
     // we need dynamic precedence here so we can resolve things like `print -next`
-    _autoquoted_bareword: $ => prec.dynamic(2, choice(
+    autoquoted_bareword: $ => prec.dynamic(2,
+      // give this autoquote the highest precedence we gots
+      prec(TERMPREC.PAREN, seq('-', choice($._bareword, $._autoquotables))),
+    ),
+    _fat_comma_autoquoted_bareword: $ => prec.dynamic(2, 
       // NOTE - these have zw lookaheads so they override just being read as barewords
       // NOTE - we have this as a hidden node + alias the actual target b/c we don't need
       // the whitespace b4 the zw assetion to be part of our node
       seq(alias(choice($._identifier, $._autoquotables), $.autoquoted_bareword), $._fat_comma_zw),
-      // give this autoquote the highest precedence we gots
-      prec(TERMPREC.PAREN, seq('-', alias(choice($._bareword, $._autoquotables), $.autoquoted_bareword))),
-    )),
+    ),
     _brace_autoquoted: $ => seq(
       alias(choice($._bareword, $._autoquotables), $.autoquoted_bareword),
       $._brace_end_zw

--- a/grammar.js
+++ b/grammar.js
@@ -401,7 +401,7 @@ module.exports = grammar({
       $.map_grep_expression,
       /* PMFUNC */
       $.bareword,
-      $.autoquoted_bareword,
+      $._autoquoted_bareword,
       $._listop,
 
       /* perly.y doesn't know about `my` because that is handled weirdly in
@@ -983,11 +983,13 @@ module.exports = grammar({
     _quotelikes: $ => choice('q', 'qq', 'qw', 'qx', 's', 'tr', 'y'),
     _autoquotables: $ => choice($._func0op, $._func1op, $._keywords, $._quotelikes),
     // we need dynamic precedence here so we can resolve things like `print -next`
-    autoquoted_bareword: $ => prec.dynamic(2, choice(
+    _autoquoted_bareword: $ => prec.dynamic(2, choice(
       // NOTE - these have zw lookaheads so they override just being read as barewords
-      seq(choice($._identifier, $._autoquotables), $._fat_comma_zw),
+      // NOTE - we have this as a hidden node + alias the actual target b/c we don't need
+      // the whitespace b4 the zw assetion to be part of our node
+      seq(alias(choice($._identifier, $._autoquotables), $.autoquoted_bareword), $._fat_comma_zw),
       // give this autoquote the highest precedence we gots
-      prec(TERMPREC.PAREN, seq('-', choice($._bareword, $._autoquotables))),
+      prec(TERMPREC.PAREN, seq('-', alias(choice($._bareword, $._autoquotables), $.autoquoted_bareword))),
     )),
     _brace_autoquoted: $ => seq(
       alias(choice($._bareword, $._autoquotables), $.autoquoted_bareword),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -72,7 +72,7 @@
  (regexp_content)
 ] @string.regex
 
-(autoquoted_bareword _?) @string.special
+(autoquoted_bareword) @string.special
 
 (use_statement (package) @type)
 (package_statement (package) @type)

--- a/test/corpus/autoquote
+++ b/test/corpus/autoquote
@@ -10,8 +10,8 @@ plain::bareword => 'here';
 (source_file
   (expression_statement
     (list_expression
-      (autoquoted_bareword
-        (comment))
+      (autoquoted_bareword)
+      (comment)
       (string_literal)))
   (expression_statement
     (list_expression

--- a/test/highlight/literals.pm
+++ b/test/highlight/literals.pm
@@ -82,3 +82,7 @@ q # this is a comment
 #             ^ variable.scalar
 qx(command);
 # <- string
+a  # hi
+#    ^comment
+# <- string.special
+ => 1;

--- a/test/highlight/literals.pm
+++ b/test/highlight/literals.pm
@@ -82,7 +82,3 @@ q # this is a comment
 #             ^ variable.scalar
 qx(command);
 # <- string
-a  # hi
-#    ^comment
-# <- string.special
- => 1;


### PR DESCRIPTION
- fix: don't include whitespace in an autoquoted bareword

will close #136 
