### PR TITLE
fix: disambiguate `shift // 1` from `shift //, 1`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -863,18 +863,23 @@ module.exports = grammar({
       choice(
         seq(
           choice(
-            $._search_slash,
-            seq(field('operator', 'm'), $._quotelike_begin)
+          seq(
+            choice(
+              $._search_slash,
+              seq(field('operator', 'm'), $._quotelike_begin)
+            ),
+            optional(regexpContent($, $._interpolated_regexp_content)),
           ),
-          optional(regexpContent($, $._interpolated_regexp_content)),
+          seq(
+            field('operator', 'm'),
+            $._apostrophe,
+            optional(regexpContent($, $._noninterpolated_string_content)), // TODO: regexp content
+          ),
         ),
-        seq(
-          field('operator', 'm'),
-          $._apostrophe,
-          optional(regexpContent($, $._noninterpolated_string_content)), // TODO: regexp content
+        $._quotelike_end,
         ),
+        '//' // empty pattern is handled specially so we can manage shift // 'default'
       ),
-      $._quotelike_end,
       optional(field('modifiers', $.match_regexp_modifiers))
     ),
     _quotelike_middle: $ => seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -96,7 +96,6 @@
 (func1op_call_expression function: _ @function.builtin)
 
 ([(function)(expression_statement (bareword))] @function.builtin
- (#set! "priority" 101)
  (#match? @function.builtin
    "^(accept|atan2|bind|binmode|bless|crypt|chmod|chown|connect|die|dbmopen|exec|fcntl|flock|getpriority|getprotobynumber|gethostbyaddr|getnetbyaddr|getservbyname|getservbyport|getsockopt|glob|index|ioctl|join|kill|link|listen|mkdir|msgctl|msgget|msgrcv|msgsend|opendir|print|printf|push|pack|pipe|return|rename|rindex|read|recv|reverse|say|select|seek|semctl|semget|semop|send|setpgrp|setpriority|seekdir|setsockopt|shmctl|shmread|shmwrite|shutdown|socket|socketpair|split|sprintf|splice|substr|system|symlink|syscall|sysopen|sysseek|sysread|syswrite|tie|truncate|unlink|unpack|utime|unshift|vec|warn|waitpid|formline|open|sort)$"
 ))

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -450,11 +450,15 @@ bool tree_sitter_perl_external_scanner_scan(
 
   if(valid_symbols[TOKEN_SEARCH_SLASH] && c == '/') {
     ADVANCE_C;
+    lexer->mark_end(lexer);
     state->delim_open = 0;
     state->delim_close = '/';
     state->delim_count = 0;
 
-    TOKEN(TOKEN_SEARCH_SLASH);
+    if (c != '/') 
+      TOKEN(TOKEN_SEARCH_SLASH);
+    /* if we didn't get a search-slash, we fall back to the main parser */
+    return false;
   }
   if(valid_symbols[TOKEN_APOSTROPHE] && c == '\'') {
     ADVANCE_C;

--- a/test/corpus/regexp
+++ b/test/corpus/regexp
@@ -112,6 +112,25 @@ sum /pattern;#still pattern/;
         (regexp_content)))))
 
 ================================================================================
+just solidus - DOR vs regex
+================================================================================
+sum //, 2, 3;
+shift // 1;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (ambiguous_function_call_expression
+      (function)
+      (match_regexp)
+      (number)
+      (number)))
+  (expression_statement
+    (binary_expression
+      (func1op_call_expression)
+      (number))))
+
+================================================================================
 substitution
 ================================================================================
 s/thing $var/$tings/xgr;


### PR DESCRIPTION
closes #149
