### PR TITLE
Implement newer perl features

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -183,8 +183,10 @@ module.exports = grammar({
       $.loop_statement,
       $.cstyle_for_statement,
       $.for_statement,
+      $.try_statement,
       alias($.block, $.block_statement),
       seq($.expression_statement, choice($._semicolon, $.__DATA__)),
+      $.defer_statement,
       ';', // this is not _semicolon so as not to generate an infinite stream of them
     ),
     package_statement: $ => choice(
@@ -240,6 +242,19 @@ module.exports = grammar({
         '(', field('list', $._expr), ')',
         field('block', $.block),
       ),
+
+    try_statement: $ => seq(
+      'try',
+      field('try_block', $.block),
+      'catch', '(', field('catch_variable', $.scalar), ')',
+      field('catch_block', $.block),
+      optseq('finally', field('finally_block', $.block)),
+    ),
+
+    defer_statement: $ => seq(
+      'defer',
+      field('block', $.block),
+    ),
 
     // perly.y calls this `sideff`
     expression_statement: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -268,9 +268,12 @@ module.exports = grammar({
     try_statement: $ => seq(
       'try',
       field('try_block', $.block),
-      'catch', '(', field('catch_variable', $.scalar), ')',
-      field('catch_block', $.block),
-      optseq('finally', field('finally_block', $.block)),
+      // regular perl only permits catch(VAR) but we get easy compatibility
+      // with Syntax::Keyword::Try too by being a bit more flexible
+      optseq('catch', optseq('(', field('catch_expr', $._expr), ')'),
+        field('catch_block', $.block)),
+      optseq('finally',
+        field('finally_block', $.block)),
     ),
 
     defer_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -174,9 +174,11 @@ module.exports = grammar({
 
     _barestmt: $ => choice(
       $.package_statement,
+      $.class_statement,
       $.use_version_statement,
       $.use_statement,
       $.subroutine_declaration_statement,
+      $.method_declaration_statement,
       $.phaser_statement,
       $.conditional_statement,
       /* TODO: given/when/default */
@@ -193,6 +195,18 @@ module.exports = grammar({
       seq('package', field('name', $.package), optional(field('version', $._version)), $._semicolon),
       seq('package', field('name', $.package), optional(field('version', $._version)), $.block),
     ),
+    class_statement: $ => choice(
+      seq('class',
+        field('name', $.package),
+        optional(field('version', $._version)), 
+        optseq(':', optional(field('attributes', $.attrlist))),
+        $._semicolon),
+      seq('class',
+        field('name', $.package),
+        optional(field('version', $._version)),
+        optseq(':', optional(field('attributes', $.attrlist))),
+        $.block),
+    ),
     use_version_statement: $ => seq($._KW_USE, field('version', $._version), $._semicolon),
     use_statement: $ => seq(
       $._KW_USE,
@@ -204,6 +218,14 @@ module.exports = grammar({
 
     subroutine_declaration_statement: $ => seq(
       'sub',
+      field('name', $.bareword),
+      optseq(':', optional(field('attributes', $.attrlist))),
+      optional($.prototype_or_signature),
+      field('body', $.block),
+    ),
+
+    method_declaration_statement: $ => seq(
+      'method',
       field('name', $.bareword),
       optseq(':', optional(field('attributes', $.attrlist))),
       optional($.prototype_or_signature),
@@ -527,7 +549,7 @@ module.exports = grammar({
 
     variable_declaration: $ => prec.left(TERMPREC.QUESTION_MARK + 1,
       seq(
-        choice('my', 'state', 'our'),
+        choice('my', 'state', 'our', 'field'),
         choice(
           field('variable', alias($._declare_scalar, $.scalar)),
           field('variable', alias($._declare_array, $.array)),
@@ -698,7 +720,7 @@ module.exports = grammar({
     _KW_FOR: $ => choice('for', 'foreach'),
     _LOOPEX: $ => choice('last', 'next', 'redo'),
 
-    _PHASE_NAME: $ => choice('BEGIN', 'INIT', 'CHECK', 'UNITCHECK', 'END'),
+    _PHASE_NAME: $ => choice('BEGIN', 'INIT', 'CHECK', 'UNITCHECK', 'END', 'ADJUST'),
 
     // Anything toke.c calls FUN0 or FUN0OP; the distinction does not matter to us
     _func0op: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -389,6 +389,7 @@ module.exports = grammar({
       $.anonymous_array_expression,
       $.anonymous_hash_expression,
       $.anonymous_subroutine_expression,
+      $.anonymous_method_expression,
       $.do_expression,
       $.eval_expression,
       $.conditional_expression,
@@ -535,6 +536,13 @@ module.exports = grammar({
 
     anonymous_subroutine_expression: $ => seq(
       'sub',
+      optseq(':', optional(field('attributes', $.attrlist))),
+      optional($.prototype_or_signature),
+      field('body', $.block),
+    ),
+
+    anonymous_method_expression: $ => seq(
+      'method',
       optseq(':', optional(field('attributes', $.attrlist))),
       optional($.prototype_or_signature),
       field('body', $.block),

--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -3,14 +3,19 @@
 
 ; fold the block-typed package statements only
 (package_statement (block)) @fold
+(class_statement (block)) @fold
 
 [(subroutine_declaration_statement)
+ (method_declaration_statement)
  (conditional_statement)
  (loop_statement)
  (for_statement)
  (cstyle_for_statement)
  (block_statement)
+ (defer_statement)
  (phaser_statement)] @fold
+
+(try_statement (block) @fold)
 
 (anonymous_subroutine_expression) @fold
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -9,6 +9,8 @@
 
 [ "while" "until" "for" "foreach" ] @repeat
 
+[ "try" "catch" "finally" ] @exception
+
 "return" @keyword.return
 
 "sub" @keyword.function
@@ -18,6 +20,7 @@
 "package" @include
 
 [
+  "defer"
   "do"
   "my" "our" "local" "state"
   "last" "next" "redo" "goto"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -14,15 +14,16 @@
 "return" @keyword.return
 
 "sub" @keyword.function
+"method" @keyword.function
 
 [ "map" "grep" "sort" ] @function.builtin
 
-"package" @include
+[ "package" "class" ] @include
 
 [
   "defer"
   "do"
-  "my" "our" "local" "state"
+  "my" "our" "local" "state" "field"
   "last" "next" "redo" "goto"
   "undef"
 ] @keyword
@@ -79,9 +80,11 @@
 
 (use_statement (package) @type)
 (package_statement (package) @type)
+(class_statement (package) @type)
 (require_expression (bareword) @type)
 
 (subroutine_declaration_statement name: (bareword) @function)
+(method_declaration_statement name: (bareword) @method)
 (attribute_name) @attribute
 (attribute_value) @string
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -13,8 +13,7 @@
 
 "return" @keyword.return
 
-"sub" @keyword.function
-"method" @keyword.function
+[ "sub" "method" ] @keyword.function
 
 [ "map" "grep" "sort" ] @function.builtin
 

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -380,6 +380,28 @@ try { A(); } catch($e) { B(); } finally { C(); }
     (block (expression_statement (function_call_expression (function)))))
     )
 ================================================================================
+Extended try / catch of Syntax::Keyword::Try
+================================================================================
+use Syntax::Keyword::Try;
+try { A(); } catch { B(); }
+try { A(); } catch($e isa Class) { B(); }
+try { A(); } finally { C(); }
+--------------------------------------------------------------------------------
+
+(source_file
+  (use_statement (package))
+  (try_statement
+    (block (expression_statement (function_call_expression (function))))
+    (block (expression_statement (function_call_expression (function)))))
+  (try_statement
+    (block (expression_statement (function_call_expression (function))))
+    (relational_expression (scalar (varname)) (bareword))
+    (block (expression_statement (function_call_expression (function)))))
+  (try_statement
+    (block (expression_statement (function_call_expression (function))))
+    (block (expression_statement (function_call_expression (function)))))
+    )
+================================================================================
 Defer
 ================================================================================
 use feature 'defer';

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -360,6 +360,38 @@ for (my $i = 0; $i < 10; $i++) { 123; }
         (number)))))
 
 ================================================================================
+try / catch
+================================================================================
+use feature 'try';
+try { A(); } catch($e) { B(); }
+try { A(); } catch($e) { B(); } finally { C(); }
+--------------------------------------------------------------------------------
+
+(source_file
+  (use_statement (package) (string_literal))
+  (try_statement
+    (block (expression_statement (function_call_expression (function))))
+    (scalar (varname))
+    (block (expression_statement (function_call_expression (function)))))
+  (try_statement
+    (block (expression_statement (function_call_expression (function))))
+    (scalar (varname))
+    (block (expression_statement (function_call_expression (function))))
+    (block (expression_statement (function_call_expression (function)))))
+    )
+================================================================================
+Defer
+================================================================================
+use feature 'defer';
+defer { A(); }
+--------------------------------------------------------------------------------
+
+(source_file
+  (use_statement (package) (string_literal))
+  (defer_statement
+    (block (expression_statement (function_call_expression (function)))))
+    )
+================================================================================
 package;
 ================================================================================
 package AAA;

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -484,3 +484,46 @@ bare blocks
     (block_statement
       (expression_statement
         (number)))))
+
+================================================================================
+Class syntax
+================================================================================
+use feature 'class';
+class Example :isa(BaseClass) {
+  field $x :attribute = 123;
+  ADJUST { $x++; }
+  method y { 456; }
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (use_statement
+    (package)
+    (string_literal))
+  (class_statement
+    (package)
+    (attrlist
+      (attribute
+        (attribute_name)
+        (attribute_value)))
+    (block
+      (expression_statement
+        (assignment_expression
+          (variable_declaration
+            (scalar
+              (varname))
+            (attrlist
+              (attribute
+                (attribute_name))))
+          (number)))
+      (phaser_statement
+        (block
+          (expression_statement
+            (postinc_expression
+              (scalar
+                (varname))))))
+      (method_declaration_statement
+        (bareword)
+        (block
+          (expression_statement
+            (number)))))))

--- a/test/corpus/subroutines
+++ b/test/corpus/subroutines
@@ -192,3 +192,29 @@ sub f :attr ($sig) {}
         (attribute_name)))
     (prototype_or_signature)
     (block)))
+
+================================================================================
+Methods
+================================================================================
+method m1 { 123; }
+method { "anon" };
+method m2 :lvalue { }
+--------------------------------------------------------------------------------
+
+(source_file
+  (method_declaration_statement
+    name: (bareword)
+    body: (block
+      (expression_statement
+        (number))))
+  (expression_statement
+    (anonymous_method_expression
+      body: (block
+        (expression_statement
+          (interpolated_string_literal)))))
+  (method_declaration_statement
+    name: (bareword)
+    attributes: (attrlist
+      (attribute
+        name: (attribute_name)))
+    body: (block)))

--- a/test/highlight/statements.pm
+++ b/test/highlight/statements.pm
@@ -60,6 +60,16 @@ for (my $i = 0; $i < 10; $i++) { 123; }
 #       ^ variable.scalar
 #               ^ variable.scalar
 #                        ^ variable.scalar
+use feature 'try';
+try { A(); } catch($e) { B(); }
+# <- exception
+#            ^^^^^ exception
+#                  ^^ variable.scalar
+try { A(); } catch($e) { B(); } finally { C(); }
+#                               ^^^^^^^ exception
+use feature 'defer';
+defer { A(); }
+# <- keyword
 package AAA;
 # <- include
 #       ^ type

--- a/test/highlight/statements.pm
+++ b/test/highlight/statements.pm
@@ -110,3 +110,16 @@ BEGIN { 123; }
 END { 456; }
 # <- keyword.phaser
 #     ^ number
+use feature 'class';
+class Example {
+# <- include
+  field $x = 123;
+# ^^^^^ keyword
+#       ^^ variable.scalar
+  ADJUST { $x++; }
+# ^^^^^^ keyword.phaser
+#          ^^ variable.scalar
+  method y { 456; }
+# ^^^^^^ keyword.function
+#        ^ method
+}


### PR DESCRIPTION
Tests and implementation stolen from my other branch, wherein they were guarded by `use feature ...` statements. Here there's simply unconditional. In practice this probably doesn't cause much problem other than maybe to users of `Try::Tiny` or similar other modules that provide `try`-like syntax in different ways.