### PR TITLE
Improve block-vs-hash detection

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -547,7 +547,7 @@ module.exports = grammar({
     // we use the precedence here to ensure that we turn map { q'thingy" => $_ } into a hashref
     // it just needs to be arbitrarily higher than the _literal rule.
     _tricky_list: $ => prec(1, seq(
-      choice($.string_literal, $.interpolated_string_literal, $.command_string, $._fat_comma_autoquoted_bareword, $.number), $._PERLY_COMMA, $._expr,
+      choice($.string_literal, $.interpolated_string_literal, $.command_string, $._fat_comma_autoquoted_bareword, $.number), $._PERLY_COMMA, $._term_rightward
     )),
     anonymous_hash_expression: $ => choice(
       seq($._PERLY_BRACE_OPEN, $._expr, '}'),

--- a/grammar.js
+++ b/grammar.js
@@ -547,7 +547,7 @@ module.exports = grammar({
     // we use the precedence here to ensure that we turn map { q'thingy" => $_ } into a hashref
     // it just needs to be arbitrarily higher than the _literal rule.
     _tricky_list: $ => prec(1, seq(
-      choice($.string_literal, $.interpolated_string_literal, $.command_string, $._fat_comma_autoquoted_bareword), $._PERLY_COMMA, $._expr,
+      choice($.string_literal, $.interpolated_string_literal, $.command_string, $._fat_comma_autoquoted_bareword, $.number), $._PERLY_COMMA, $._expr,
     )),
     anonymous_hash_expression: $ => choice(
       seq($._PERLY_BRACE_OPEN, $._expr, '}'),

--- a/grammar.js
+++ b/grammar.js
@@ -57,13 +57,13 @@ binop.nonassoc = ($, op, term) =>
     )
   )
 
-regexpContent = ($, node) => 
+regexpContent = ($, node) =>
   field('content', alias(node, $.regexp_content))
 
-replacement = ($, node) => 
+replacement = ($, node) =>
   alias(node, $.replacement)
 
-trContent = ($, node) => 
+trContent = ($, node) =>
   field('content', alias(node, $.transliteration_content))
 
 /**
@@ -206,7 +206,7 @@ module.exports = grammar({
     class_statement: $ => choice(
       seq('class',
         field('name', $.package),
-        optional(field('version', $._version)), 
+        optional(field('version', $._version)),
         optseq(':', optional(field('attributes', $.attrlist))),
         $._semicolon),
       seq('class',
@@ -623,7 +623,7 @@ module.exports = grammar({
     // we use the precedence here to ensure that we turn map { q'thingy" => $_ } into a hashref
     // it just needs to be arbitrarily higher than the _literal rule
     _tricky_hashref: $ => prec(1, seq(
-      $._PERLY_BRACE_OPEN, choice($.string_literal, $.interpolated_string_literal, $.command_string), $._PERLY_COMMA, $._expr, '}'
+      $._PERLY_BRACE_OPEN, choice($.string_literal, $.interpolated_string_literal, $.command_string, $._fat_comma_autoquoted_bareword), $._PERLY_COMMA, $._expr, '}'
     )),
 
     map_grep_expression: $ => prec.left(TERMPREC.LSTOP, choice(
@@ -1099,7 +1099,7 @@ module.exports = grammar({
         token.immediate(prec(1, /[rwxoRWXOezsfdlpSbctugkTBMAC]((::)|([a-zA-Z_]\w*))+/))
       ))),
     ),
-    _fat_comma_autoquoted_bareword: $ => prec.dynamic(2, 
+    _fat_comma_autoquoted_bareword: $ => prec.dynamic(2,
       // NOTE - these have zw lookaheads so they override just being read as barewords
       // NOTE - we have this as a hidden node + alias the actual target b/c we don't need
       // the whitespace b4 the zw assetion to be part of our node

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4251,6 +4251,10 @@
               {
                 "type": "SYMBOL",
                 "name": "command_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_fat_comma_autoquoted_bareword"
               }
             ]
           },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3537,7 +3537,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_expr"
+            "name": "_term_rightward"
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -26,24 +26,8 @@
         }
       ]
     },
-    "_HASHBRACK": {
-      "type": "STRING",
-      "value": "{"
-    },
     "_PERLY_BRACE_OPEN": {
-      "type": "ALIAS",
-      "content": {
-        "type": "TOKEN",
-        "content": {
-          "type": "PREC",
-          "value": 2,
-          "content": {
-            "type": "STRING",
-            "value": "{"
-          }
-        }
-      },
-      "named": false,
+      "type": "STRING",
       "value": "{"
     },
     "block": {
@@ -3516,28 +3500,102 @@
         }
       ]
     },
+    "_tricky_list": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "string_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolated_string_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "command_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_fat_comma_autoquoted_bareword"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_PERLY_COMMA"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        ]
+      }
+    },
     "anonymous_hash_expression": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_HASHBRACK"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_PERLY_BRACE_OPEN"
+            },
             {
               "type": "SYMBOL",
               "name": "_expr"
             },
             {
-              "type": "BLANK"
+              "type": "STRING",
+              "value": "}"
             }
           ]
         },
         {
-          "type": "STRING",
-          "value": "}"
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_PERLY_BRACE_OPEN"
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_PERLY_BRACE_OPEN"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_tricky_list"
+              },
+              "named": true,
+              "value": "list_expression"
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
         }
       ]
     },
@@ -4227,52 +4285,6 @@
         }
       ]
     },
-    "_tricky_hashref": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_PERLY_BRACE_OPEN"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "string_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolated_string_literal"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "command_string"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_fat_comma_autoquoted_bareword"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_PERLY_COMMA"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_expr"
-          },
-          {
-            "type": "STRING",
-            "value": "}"
-          }
-        ]
-      }
-    },
     "map_grep_expression": {
       "type": "PREC_LEFT",
       "value": 4,
@@ -4315,22 +4327,8 @@
                 "type": "FIELD",
                 "name": "callback",
                 "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_term"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_tricky_hashref"
-                      },
-                      "named": true,
-                      "value": "anonymous_hash_expression"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_term"
                 }
               },
               {
@@ -4366,22 +4364,8 @@
                 "type": "FIELD",
                 "name": "callback",
                 "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_term"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_tricky_hashref"
-                      },
-                      "named": true,
-                      "value": "anonymous_hash_expression"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_term"
                 }
               },
               {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3524,6 +3524,10 @@
               {
                 "type": "SYMBOL",
                 "name": "_fat_comma_autoquoted_bareword"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "number"
               }
             ]
           },

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -73,19 +73,62 @@ Anonymous array
         (number)
         (number)))))
 
+
+================================================================================
+Blocks that look like hashes
+================================================================================
+{ rand, 7 }
+{ qr/thing/, 5 }
+{ 1 + 2, 3 }
+--------------------------------------------------------------------------------
+(source_file
+      (block_statement
+        (expression_statement
+          (list_expression
+            (func1op_call_expression)
+            (number))))
+      (block_statement
+        (expression_statement
+          (list_expression
+            (quoted_regexp
+              (regexp_content))
+            (number))))
+      (block_statement
+        (expression_statement
+          (list_expression
+            (binary_expression
+              (number)
+              (number))
+            (number)))))
+
 ================================================================================
 Anonymous hash
 ================================================================================
-+{ 1, 2 };
+{ 1, 2 };
+{ ting => 2 };
+{};
++{ rand, 7 };
 --------------------------------------------------------------------------------
 
 (source_file
   (expression_statement
-    (unary_expression
       (anonymous_hash_expression
         (list_expression
           (number)
-          (number))))))
+          (number))))
+  (expression_statement
+    (anonymous_hash_expression
+      (list_expression
+        (autoquoted_bareword)
+        (number))))
+  (expression_statement
+    (anonymous_hash_expression))
+  (expression_statement
+   (unary_expression
+    (anonymous_hash_expression
+     (list_expression
+      (func1op_call_expression)
+      (number))))))
 
 ================================================================================
 Assignment

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -279,7 +279,7 @@ print $sner and die;
 ambiguous funcs - tricky block vs hashref
 ================================================================================
 takes_a_hash { 1, 2, 3, 4 };
-its_a_block { 1, 2, 3, 4; 9 };
+first { $_ > 19 } @numbas;
 for_sure_a_hash { hi => 'there' }, 9001;
 --------------------------------------------------------------------------------
 
@@ -297,14 +297,14 @@ for_sure_a_hash { hi => 'there' }, 9001;
     (ambiguous_function_call_expression
       (function)
       (indirect_object
-        (expression_statement
-          (list_expression
-            (number)
-            (number)
-            (number)
-            (number)))
-        (expression_statement
-          (number)))))
+        (block
+          (expression_statement
+            (relational_expression
+              (scalar
+                (varname))
+              (number)))))
+      (array
+        (varname))))
   (expression_statement
     (ambiguous_function_call_expression
       (function)

--- a/test/corpus/map-grep
+++ b/test/corpus/map-grep
@@ -98,20 +98,22 @@ map { even_this   => $_ }, @array;     # perl guesses EXPR; slightly more SURPRI
   (expression_statement
     (map_grep_expression
       (anonymous_hash_expression
-        (interpolated_string_literal
-          (escape_sequence)
-          (scalar
-            (varname)))
-        (number))
+        (list_expression
+          (interpolated_string_literal
+            (escape_sequence)
+            (scalar
+              (varname)))
+          (number)))
       (array
         (varname))))
   (comment)
   (expression_statement
     (map_grep_expression
       (anonymous_hash_expression
-        (autoquoted_bareword)
-        (scalar
-          (varname)))
+        (list_expression
+          (autoquoted_bareword)
+          (scalar
+            (varname))))
       (array
         (varname))))
   (comment)

--- a/test/corpus/map-grep
+++ b/test/corpus/map-grep
@@ -67,6 +67,7 @@ map - EXPR form
 map +( lc($_) => 1 ), @array;      # this is EXPR and works!
 map +{ lc($_) => 1 }, @array;      # EXPR, so needs comma at end
 map { "\L$_"   => 1 }, @array;     # perl guesses EXPR; SURPRISE!
+map { even_this   => $_ }, @array;     # perl guesses EXPR; slightly more SURPRISE!
 # thanks perldoc, for all the examples!
 --------------------------------------------------------------------------------
 
@@ -102,6 +103,15 @@ map { "\L$_"   => 1 }, @array;     # perl guesses EXPR; SURPRISE!
           (scalar
             (varname)))
         (number))
+      (array
+        (varname))))
+  (comment)
+  (expression_statement
+    (map_grep_expression
+      (anonymous_hash_expression
+        (autoquoted_bareword)
+        (scalar
+          (varname)))
       (array
         (varname))))
   (comment)


### PR DESCRIPTION
- feat: treat fat comma quoteds as hash-discriminators
- feat: treat numbers as hash-discriminators
- fix: move up tricky hashref handling to include raw blocks!
- fix: use a better test case for ambiguous map-a-likes

closes #177
