### PR TITLE
fix: make braces appear properly for matching queries

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -409,20 +409,20 @@ module.exports = grammar({
     slice_container_variable: $ => seq('@', $._var_indirob),
     slice_expression: $ => choice(
       seq(field('array', $.slice_container_variable), '[', $._expr, ']'),
-      seq(field('hash', $.slice_container_variable), '{', $._expr, '}'),
+      seq(field('hash', $.slice_container_variable), '{', $._hash_key, '}'),
       prec.left(TERMPREC.ARROW,
         seq(field('arrayref', $._term), '->', '@', '[', $._expr, ']')),
       prec.left(TERMPREC.ARROW,
-        seq(field('hashref', $._term), '->', '@', '{', $._expr, '}')),
+        seq(field('hashref', $._term), '->', '@', '{', $._hash_key, '}')),
     ),
     keyval_container_variable: $ => seq($._HASH_PERCENT, $._var_indirob),
     keyval_expression: $ => choice(
       seq(field('array', $.keyval_container_variable), '[', $._expr, ']'),
-      seq(field('hash', $.keyval_container_variable), '{', $._expr, '}'),
+      seq(field('hash', $.keyval_container_variable), '{', $._hash_key, '}'),
       prec.left(TERMPREC.ARROW,
         seq(field('arrayref', $._term), '->', '%', '[', $._expr, ']')),
       prec.left(TERMPREC.ARROW,
-        seq(field('hashref', $._term), '->', '%', '{', $._expr, '}')),
+        seq(field('hashref', $._term), '->', '%', '{', $._hash_key, '}')),
     ),
 
     _term: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -69,6 +69,8 @@ replacement = ($, node) =>
 trContent = ($, node) =>
   field('content', alias(node, $.transliteration_content))
 
+aliasMany = (to, tokens) => tokens.map(t => alias(t, to))
+
 /**
  *
  * @param {RuleOrLiteral[]} terms
@@ -952,14 +954,20 @@ module.exports = grammar({
       // Most array punctuation vars do not interpolate
       // we need the zw quote-end for "" (we leave regular _end so the scanner looks for it)
       seq('@', choice(/[^A-Za-z0-9_\$'+:-]/, $._quotelike_end_zw, $._quotelike_end)),
-      // for space sensitive hash/array derefs
-      '-> ',
-      '->@ ',
-      '-',
+      ...aliasMany('not-interpolated',
+        [
+          // for space sensitive hash/array derefs we have a space-included version of the
+          // arrow to beat the non-space version in lexical prec
+          '-> ',
+          '->@ ',
+          // these are re-aliased to not-interpolated so that a query for the actual
+          // syntactic token won't match
+          '-',
+          '{',
+          '[',
+        ])
       // a drop poor-man's, but we don't want queries mistakenly picking up these tokens as
       // part of a bracket pair
-      alias('{', '-> '),
-      alias('[', '-> '),
     ),
     _interpolated_string_content: $ => repeat1(
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -957,9 +957,12 @@ module.exports = grammar({
       ...aliasMany('not-interpolated',
         [
           // for space sensitive hash/array derefs we have a space-included version of the
-          // arrow to beat the non-space version in lexical prec
+          // arrow to beat the non-space version in lexical prec. this is hacky and gross
+          // but eh
           '-> ',
           '->@ ',
+          "->\n",
+          "->@\n",
           // these are re-aliased to not-interpolated so that a query for the actual
           // syntactic token won't match
           '-',

--- a/queries/matchup.scm
+++ b/queries/matchup.scm
@@ -22,9 +22,8 @@
 ) @scope.fun
 (return_expression "return" @mid.fun.1)
 
-(_
-  [
-    ("'" @open.quotelike "'" @close.quotelike)
-    ("'" @open.quotelike (_) "'"+ @mid.quotelike.1 (replacement) "'" @close.quotelike)
-  ]
-) @scope.quotelike
+[
+  (_ "'" @open.quotelike (string_content) "'" @close.quotelike)
+  (quoted_regexp "'" @open.quotelike "'" @close.quotelike)
+  (_ "'" @open.quotelike (_) "'"+ @mid.quotelike.1 (replacement) "'" @close.quotelike)
+] @scope.quotelike

--- a/queries/matchup.scm
+++ b/queries/matchup.scm
@@ -22,3 +22,9 @@
   (quoted_regexp "'" @open.quotelike "'" @close.quotelike)
   (_ "'" @open.quotelike (_) "'"+ @mid.quotelike.1 (replacement) "'" @close.quotelike)
 ] @scope.quotelike
+
+(try_statement
+  "try" @open.try
+  "catch"? @mid.try.1
+  "finally"? @close.try
+  ) @scope.try

--- a/queries/matchup.scm
+++ b/queries/matchup.scm
@@ -5,11 +5,6 @@
     (block "}" @close.if) .
 ) @scope.if
 
-(conditional_expression
-  "?" @open.ternary
-  ":" @mid.ternary.1
-  ) @scope.ternary
-
 (_
   ["for" "foreach" "while" "unless"] @open.loop
   (block "}" @close.loop) .

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6573,11 +6573,8 @@
                 }
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "{"
-                }
+                "type": "STRING",
+                "value": "{"
               },
               {
                 "type": "FIELD",
@@ -6715,11 +6712,8 @@
                 }
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "["
-                }
+                "type": "STRING",
+                "value": "["
               },
               {
                 "type": "SYMBOL",
@@ -6880,15 +6874,6 @@
           "type": "ALIAS",
           "content": {
             "type": "STRING",
-            "value": "->"
-          },
-          "named": false,
-          "value": "not-interpolated"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "STRING",
             "value": "-> "
           },
           "named": false,
@@ -6898,7 +6883,7 @@
           "type": "ALIAS",
           "content": {
             "type": "STRING",
-            "value": "->@"
+            "value": "->@ "
           },
           "named": false,
           "value": "not-interpolated"
@@ -6907,7 +6892,16 @@
           "type": "ALIAS",
           "content": {
             "type": "STRING",
-            "value": "->@ "
+            "value": "->\n"
+          },
+          "named": false,
+          "value": "not-interpolated"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "->@\n"
           },
           "named": false,
           "value": "not-interpolated"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6463,8 +6463,12 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "STRING",
-                  "value": "->["
+                  "value": "->"
                 }
+              },
+              {
+                "type": "STRING",
+                "value": "["
               },
               {
                 "type": "FIELD",
@@ -6565,8 +6569,12 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "STRING",
-                  "value": "->{"
+                  "value": "->"
                 }
+              },
+              {
+                "type": "STRING",
+                "value": "{"
               },
               {
                 "type": "FIELD",
@@ -6674,7 +6682,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_expr"
+              "name": "_hash_key"
             },
             {
               "type": "STRING",
@@ -6700,8 +6708,12 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "STRING",
-                  "value": "->@["
+                  "value": "->@"
                 }
+              },
+              {
+                "type": "STRING",
+                "value": "["
               },
               {
                 "type": "SYMBOL",
@@ -6736,8 +6748,12 @@
                 }
               },
               {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
                 "type": "SYMBOL",
-                "name": "_expr"
+                "name": "_hash_key"
               },
               {
                 "type": "STRING",
@@ -6856,15 +6872,33 @@
         },
         {
           "type": "STRING",
+          "value": "-> "
+        },
+        {
+          "type": "STRING",
+          "value": "->@ "
+        },
+        {
+          "type": "STRING",
           "value": "-"
         },
         {
-          "type": "STRING",
-          "value": "{"
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "{"
+          },
+          "named": false,
+          "value": "-> "
         },
         {
-          "type": "STRING",
-          "value": "["
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "["
+          },
+          "named": false,
+          "value": "-> "
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2191,7 +2191,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_expr"
+              "name": "_hash_key"
             },
             {
               "type": "STRING",
@@ -2264,7 +2264,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_expr"
+                "name": "_hash_key"
               },
               {
                 "type": "STRING",
@@ -2333,7 +2333,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_expr"
+              "name": "_hash_key"
             },
             {
               "type": "STRING",
@@ -2406,7 +2406,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_expr"
+                "name": "_hash_key"
               },
               {
                 "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6573,8 +6573,11 @@
                 }
               },
               {
-                "type": "STRING",
-                "value": "{"
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "{"
+                }
               },
               {
                 "type": "FIELD",
@@ -6712,8 +6715,11 @@
                 }
               },
               {
-                "type": "STRING",
-                "value": "["
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "["
+                }
               },
               {
                 "type": "SYMBOL",
@@ -6871,16 +6877,49 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "-> "
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "->"
+          },
+          "named": false,
+          "value": "not-interpolated"
         },
         {
-          "type": "STRING",
-          "value": "->@ "
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "-> "
+          },
+          "named": false,
+          "value": "not-interpolated"
         },
         {
-          "type": "STRING",
-          "value": "-"
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "->@"
+          },
+          "named": false,
+          "value": "not-interpolated"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "->@ "
+          },
+          "named": false,
+          "value": "not-interpolated"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "-"
+          },
+          "named": false,
+          "value": "not-interpolated"
         },
         {
           "type": "ALIAS",
@@ -6889,7 +6928,7 @@
             "value": "{"
           },
           "named": false,
-          "value": "-> "
+          "value": "not-interpolated"
         },
         {
           "type": "ALIAS",
@@ -6898,7 +6937,7 @@
             "value": "["
           },
           "named": false,
-          "value": "-> "
+          "value": "not-interpolated"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6409,6 +6409,13 @@
         }
       ]
     },
+    "_interp_arrow": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "->"
+      }
+    },
     "_array_element_interpolation": {
       "type": "CHOICE",
       "members": [
@@ -6460,11 +6467,8 @@
                 "name": "scalar"
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "->"
-                }
+                "type": "SYMBOL",
+                "name": "_interp_arrow"
               },
               {
                 "type": "STRING",
@@ -6566,11 +6570,8 @@
                 "name": "scalar"
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "->"
-                }
+                "type": "SYMBOL",
+                "name": "_interp_arrow"
               },
               {
                 "type": "STRING",
@@ -6705,11 +6706,12 @@
                 }
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "->@"
-                }
+                "type": "SYMBOL",
+                "name": "_interp_arrow"
+              },
+              {
+                "type": "STRING",
+                "value": "@"
               },
               {
                 "type": "STRING",
@@ -6741,11 +6743,12 @@
                 }
               },
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "->@{"
-                }
+                "type": "SYMBOL",
+                "name": "_interp_arrow"
+              },
+              {
+                "type": "STRING",
+                "value": "@"
               },
               {
                 "type": "STRING",
@@ -6871,41 +6874,52 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "STRING",
-            "value": "-> "
-          },
-          "named": false,
-          "value": "not-interpolated"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "scalar"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_interp_arrow"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_no_interp_whitespace_zw"
+            }
+          ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "STRING",
-            "value": "->@ "
-          },
-          "named": false,
-          "value": "not-interpolated"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "scalar"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_interp_arrow"
+            },
+            {
+              "type": "STRING",
+              "value": "@"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_no_interp_whitespace_zw"
+            }
+          ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "STRING",
-            "value": "->\n"
-          },
-          "named": false,
-          "value": "not-interpolated"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "STRING",
-            "value": "->@\n"
-          },
-          "named": false,
-          "value": "not-interpolated"
-        },
+          "type": "SYMBOL",
+          "name": "_nonvar_interpolation_fallbacks"
+        }
+      ]
+    },
+    "_nonvar_interpolation_fallbacks": {
+      "type": "CHOICE",
+      "members": [
         {
           "type": "ALIAS",
           "content": {
@@ -7564,7 +7578,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_interpolation_fallbacks"
+            "name": "_nonvar_interpolation_fallbacks"
           },
           {
             "type": "SEQ",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -450,8 +450,11 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     }
   }
 
-  if (iswspace(c) && valid_symbols[TOKEN_NO_INTERP_WHITESPACE_ZW])
-    TOKEN(TOKEN_NO_INTERP_WHITESPACE_ZW);
+  if (iswspace(c) && valid_symbols[TOKEN_NO_INTERP_WHITESPACE_ZW]) {
+      lexer->mark_end(lexer);
+      ADVANCE_C;
+      TOKEN(TOKEN_NO_INTERP_WHITESPACE_ZW);
+  }
   skip_ws_to_eol(lexer);
   /* heredocs override everything, so they must be here before */
   if (valid_symbols[TOKEN_HEREDOC_START]) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -451,8 +451,6 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
   }
 
   if (iswspace(c) && valid_symbols[TOKEN_NO_INTERP_WHITESPACE_ZW]) {
-      lexer->mark_end(lexer);
-      ADVANCE_C;
       TOKEN(TOKEN_NO_INTERP_WHITESPACE_ZW);
   }
   skip_ws_to_eol(lexer);

--- a/test/corpus/autoquote
+++ b/test/corpus/autoquote
@@ -60,6 +60,8 @@ hash autoquoting
 ================================================================================
 $hash{quoted};
 $hash{shift};
+$hash->%{thing};
+@hash{thing};
 --------------------------------------------------------------------------------
 
 (source_file
@@ -72,7 +74,17 @@ $hash{shift};
     (hash_element_expression
       hash: (container_variable
         (varname))
-      key: (autoquoted_bareword))))
+      key: (autoquoted_bareword)))
+  (expression_statement
+    (keyval_expression
+      hashref: (scalar
+        (varname))
+      (autoquoted_bareword)))
+  (expression_statement
+    (slice_expression
+      hash: (slice_container_variable
+        (varname))
+      (autoquoted_bareword))))
 
 ================================================================================
 hash autoquoting for quotelike

--- a/test/corpus/heredocs
+++ b/test/corpus/heredocs
@@ -151,12 +151,21 @@ weird heredoc interpolation (gh#133)
 <<EOF;
 @
 EOF
+<<EOF;
+$sner->
+EOF
 --------------------------------------------------------------------------------
 
 (source_file
   (expression_statement
     (heredoc_token))
   (heredoc_content
+    (heredoc_end))
+  (expression_statement
+    (heredoc_token))
+  (heredoc_content
+    (scalar
+      (varname))
     (heredoc_end)))
 
 ================================================================================

--- a/test/corpus/interpolation
+++ b/test/corpus/interpolation
@@ -100,7 +100,7 @@ Space skips interpolation
 ================================================================================
 "an array $elem [0]";
 "an array $elem ->[1] deref";
-"an array $elem-> [1] deref";
+"an array $elem-> [1] deref and a slice $slice->@ [1..10]";
 "an array $elem->
 [1] deref";
 --------------------------------------------------------------------------------
@@ -119,8 +119,9 @@ Space skips interpolation
   (expression_statement
     (interpolated_string_literal
       (string_content
-        (scalar
-          (varname)))))
+        (scalar (varname))
+        (scalar (varname))
+        )))
   (expression_statement
     (interpolated_string_literal
       (string_content

--- a/test/corpus/interpolation
+++ b/test/corpus/interpolation
@@ -144,7 +144,7 @@ Slice interpolation
         (slice_expression
           hash: (slice_container_variable
             (varname))
-          (bareword)))))
+          (autoquoted_bareword)))))
   (expression_statement
     (interpolated_string_literal
       content: (string_content

--- a/test/corpus/interpolation
+++ b/test/corpus/interpolation
@@ -101,9 +101,16 @@ Space skips interpolation
 "an array $elem [0]";
 "an array $elem ->[1] deref";
 "an array $elem-> [1] deref";
+"an array $elem->
+[1] deref";
 --------------------------------------------------------------------------------
 
 (source_file
+  (expression_statement
+    (interpolated_string_literal
+      (string_content
+        (scalar
+          (varname)))))
   (expression_statement
     (interpolated_string_literal
       (string_content

--- a/test/highlight/interpolation.pm
+++ b/test/highlight/interpolation.pm
@@ -13,3 +13,8 @@
 # ^^ string
  "@)";
 # ^^ string
+"$thing-> {ting}    also $shtuff ->{hi}";
+#      ^^^^^ string              ^^^ string
+"$thing->{time}";
+#        ^ punctuation.bracket
+#         ^^ string.special


### PR DESCRIPTION
- **feat: brace autoquoting for slices and keyvals**
- **feat: output brackets correctly in space-sensitive interpolations**
- **feat: make matchup queries the way we like 'em**
- **feat: hide away interp overrides as anon not-interpolated**
- **fix: make braces after newline also cancel the interp**
