### PR TITLE
feat: support arbitrary flags on eq and friends (cuz THE FUTURE)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -573,9 +573,11 @@ module.exports = grammar({
     },
 
     // perl.y calls this `termeqop`
+    equality_modifiers: $ => token(prec(2, /[a-z]+/)),
     equality_expression: $ =>
       choice(
-        prec.left(TERMPREC.CHEQOP, binop(choice('==', '!=', 'eq', '===', 'equ', 'eqr', 'ne'), $._term)), // _CHEQOP
+        prec.left(TERMPREC.CHEQOP,
+          binop(seq(choice('==', '!=', 'eq', '===', 'equ', 'eqr', 'ne'), optseq(':', field('modifiers', $.equality_modifiers))), $._term)), // _CHEQOP
         prec.right(TERMPREC.CHEQOP, binop.nonassoc($, choice('<=>', 'cmp', '~~'), $._term)), // _NCEQOP
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3529,6 +3529,17 @@
         }
       ]
     },
+    "equality_modifiers": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 2,
+        "content": {
+          "type": "PATTERN",
+          "value": "[a-z]+"
+        }
+      }
+    },
     "equality_expression": {
       "type": "CHOICE",
       "members": [
@@ -3550,35 +3561,65 @@
                 "type": "FIELD",
                 "name": "operator",
                 "content": {
-                  "type": "CHOICE",
+                  "type": "SEQ",
                   "members": [
                     {
-                      "type": "STRING",
-                      "value": "=="
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "=="
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "!="
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "eq"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "==="
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "equ"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "eqr"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "ne"
+                        }
+                      ]
                     },
                     {
-                      "type": "STRING",
-                      "value": "!="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "eq"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "==="
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "equ"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "eqr"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "ne"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ":"
+                            },
+                            {
+                              "type": "FIELD",
+                              "name": "modifiers",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "equality_modifiers"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
                     }
                   ]
                 }


### PR DESCRIPTION
This PR implements parsing for the `eq:u` form of undef-aware equality. I'll leave it
pending until the relevant PPC is fully hashed out
