### PR TITLE
fix: stale mark_end after keyword-boundary peek breaks string-arg method calls

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -617,7 +617,14 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
   // the previous expression is done.  Also fires when a recovery token
   // was just emitted (recovery_emitted flag) since the newline was already
   // consumed by the previous call.
-  if ((crossed_newline || recovery_emitted) && !is_ERROR && any_recovery_valid) {
+  // Gate on the first-char filter so we don't call MARK_END (and freeze
+  // the token end at the keyword-start position) when the lookahead can't
+  // possibly start a keyword.  Without this, a later TOKEN() emission
+  // (e.g. TOKEN_APOSTROPHE/TOKEN_DOUBLE_QUOTE which do ADVANCE_C+TOKEN
+  // and never re-mark) inherits the stale mark and reports a zero-width
+  // open-quote, which derails the string body.
+  if ((crossed_newline || recovery_emitted) && !is_ERROR && any_recovery_valid &&
+      !KEYWORD_FIRST_CHAR_FILTER(c)) {
     MARK_END;  // zero-width position for recovery tokens
     enum PeekResult peek = peek_is_statement_keyword(lexer);
     if (peek == PEEK_KEYWORD) {

--- a/test/corpus/error_recovery
+++ b/test/corpus/error_recovery
@@ -193,3 +193,56 @@ package Bar;
       arguments: (anonymous_array_expression)))
   (package_statement
     name: (package)))
+
+================================================================================
+Keyword boundary - method call with string-keyed fat comma on next line
+================================================================================
+$x->foo(
+    'a' => 1
+);
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (method_call_expression
+      invocant: (scalar
+        (varname))
+      method: (method)
+      arguments: (list_expression
+        (string_literal
+          content: (string_content))
+        (number)))))
+
+================================================================================
+Keyword boundary - method call with double-quoted string on next line
+================================================================================
+$x->foo(
+"hi"
+);
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (method_call_expression
+      invocant: (scalar
+        (varname))
+      method: (method)
+      arguments: (interpolated_string_literal
+        content: (string_content)))))
+
+================================================================================
+Keyword boundary - method call with backtick command on next line
+================================================================================
+$x->foo(
+`ls`
+);
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (method_call_expression
+      invocant: (scalar
+        (varname))
+      method: (method)
+      arguments: (command_string
+        content: (string_content)))))


### PR DESCRIPTION
## Summary

- The keyword-boundary recovery code added in #226 (`scanner.c:620`) marks a zero-width token end *before* the peek so that any recovery tokens it emits are zero-width at the keyword start. When peek returns `PEEK_NO_MATCH` the block falls through with that mark still frozen, and the next `ADVANCE_C; TOKEN(...)` path that doesn't re-mark (`TOKEN_APOSTROPHE`, `TOKEN_DOUBLE_QUOTE`, `TOKEN_BACKTICK`) emits a zero-width open quote — the parser shifts an empty token, scanner state is now mid-string, the very next external lex re-reads the same quote char as the *close* quote of an empty string, and everything downstream goes to ERROR.
- Symptom: shapes extremely common in Mojolicious / Moo / DBIC / Minion code parse as a top-level `(ERROR ...)`, taking the entire enclosing sub or package down with them in the LSP:
  ```perl
  $app->minion->add_task(
      'send_email' => sub ($job, $to, $body) { ... }
  );
  ```
- Fix is to gate on `KEYWORD_FIRST_CHAR_FILTER(c)` before entering the recovery block so we don't pollute `mark_end` for any lookahead that can't possibly start a statement keyword.

## Impact

Measured against a 1,130-file production CRM codebase, with a 10s per-file parse timeout:

| | failed parses | success rate | wall time |
|---|---|---|---|
| before | 371 | 67.17% | ~4.4s |
| after  | 94  | 91.68% | ~2.0s |

277 fewer files with parse errors, no infinite loops, faster on average (less GLR thrashing through bogus recovery branches).

## Test plan

- [x] `tree-sitter test` — all 216 corpus tests pass (213 pre-existing + 3 added)
- [x] Added regression tests in `test/corpus/error_recovery` covering the `'...'`, `"..."`, and `` `...` `` variants
- [x] 1,130-file external corpus run; failure count dropped 371 → 94, no timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)