### PR TITLE
fix: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A tree-sitter parser, for Perl!",
   "main": "bindings/node",
   "types": "bindings/node",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tree-sitter-perl/tree-sitter-perl.git"
+  },
   "scripts": {
     "test": "tree-sitter generate && tree-sitter test",
     "install": "node-gyp-build",


### PR DESCRIPTION
Adds the `repository` field to `package.json`.

npm trusted publishing (OIDC) attaches a sigstore provenance statement, and npm validates that `package.json`'s `repository.url` matches the source repo. With the field missing it publishes the provenance and then rejects the tarball:

```
npm error 422 ... Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match
"https://github.com/tree-sitter-perl/tree-sitter-perl" from provenance
```

This surfaced while releasing tree-sitter-pod v1.1.0 (same fix applied there). Setting it now avoids the npm job failing the next time perl publishes via trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)