### PR TITLE
Allow s{}{}/tr{}{} replacement pair to use its own delimiter

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -894,6 +894,17 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     }
     MARK_END;
 
+    // In a paired multi-part quote (s{}{}, tr[][], ...), the replacement pair
+    // opens a fresh quote whose delimiter may differ from the pattern's. The
+    // pattern's quote is still on top of the stack (middle_close consumes its
+    // closer but doesn't pop it), so its closer would wrongly stay active while
+    // we scan the replacement. Now that the second pair is opening, retire it.
+    // MIDDLE_SKIP being a valid symbol here means we're at the middle choice
+    // point (between pattern and replacement) rather than an initial begin.
+    if (valid_symbols[TOKEN_QUOTELIKE_MIDDLE_SKIP] && state->quotes.size) {
+      lexerstate_pop_quote(state, state->quotes.size);
+    }
+
     lexerstate_push_quote(state, delim);
     // TODO - fill in this debug print here?
     // DEBUG("Generic QSTRING open='%c' close='%c'\n", state->delim_open,

--- a/test/corpus/regexp
+++ b/test/corpus/regexp
@@ -237,3 +237,59 @@ s/[\s]+/replaced/g;
         (escape_sequence))
       (replacement)
       (substitution_regexp_modifiers))))
+
+================================================================================
+substitution with bracketing delimiters (replacement pair may differ)
+================================================================================
+s{foo}{bar};
+s{foo}[bar];
+s(foo)<bar>;
+s{foo}/bar/;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (substitution_regexp
+      (regexp_content)
+      (replacement)))
+  (expression_statement
+    (substitution_regexp
+      (regexp_content)
+      (replacement)))
+  (expression_statement
+    (substitution_regexp
+      (regexp_content)
+      (replacement)))
+  (expression_statement
+    (substitution_regexp
+      (regexp_content)
+      (replacement))))
+
+================================================================================
+substitution replacement delimited independently of pattern
+================================================================================
+s{foo}[ba}r];
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (substitution_regexp
+      (regexp_content)
+      (replacement))))
+
+================================================================================
+transliteration with bracketing delimiters
+================================================================================
+tr{abc}[xyz];
+y[abc]{xyz};
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (transliteration_expression
+      (transliteration_content)
+      (replacement)))
+  (expression_statement
+    (transliteration_expression
+      (transliteration_content)
+      (replacement))))


### PR DESCRIPTION
Perl lets a bracketing-delimited substitution or transliteration give its replacement pair a **separate, independently-delimited** quote — `s{foo}[bar]`, `s(foo)<bar>`, `s{foo}/bar/`, `tr{abc}[xyz]`, `y[abc]{xyz}`. We only handled the case where the replacement repeated the pattern's delimiter.

### Root cause

The scanner consumes the pattern pair's closer at `_quotelike_middle_close` but never pops that quote off the stack. Its closer therefore stays active while scanning the replacement:

- with a **matching** second delimiter this merely leaked the stale quote (latent bug);
- with a **differing** one the pattern's closer terminated the replacement early — e.g. `s{foo}[ba}r]` stopped at the `}`, parsing the replacement as just `ba`.

### Fix

When the replacement pair opens (the `_quotelike_begin` reached via the middle choice — distinguishable because `MIDDLE_SKIP` is simultaneously a valid symbol there), pop the now-finished pattern quote so only the replacement pair's delimiter is active. One small conditional in the scanner; fixes both the mismatched-delimiter parse and the stack leak.

### Tests

3 new corpus cases in `test/corpus/regexp` (bracketing delimiters, replacement delimited independently of the pattern, transliteration). Full suite green: **222/222**. Verified `s{a}{b}; my \$x = {k=>1};` parses clean (no leaked quote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)