### PR TITLE
Fix `<` mis-lexed as fileglob after a bareword (gh#210)

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -662,9 +662,25 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
           while (isidcont(c)) ADVANCE_C;
           // if ident chars took us until the closing `>` then we're readline FILEHANDLE
           if (c == '>') TOKEN(TOKEN_OPEN_READLINE_BRACKET);
-          // otherwise we're a fileglob operator, and we set up our string parse + be excellent
-          lexerstate_push_quote(state, '<');
-          TOKEN(TOKEN_OPEN_FILEGLOB_BRACKET);
+          // otherwise we *might* be a fileglob operator (`<*.c>`, `<$dir/*>`).
+          // But a bare `<` followed by a term (e.g. `CONST < 0`) is the
+          // relational less-than operator, not a fileglob. The two are only
+          // distinguishable by whether a closing `>` appears before the end of
+          // the statement: a real fileglob is always `<...>` on a single line.
+          // So we scan ahead (without moving the marked token end, which still
+          // covers just `<`) and only commit to a fileglob if we find a `>`. If
+          // we don't, we bail and let the grammar lex `<` as the operator.
+          if (valid_symbols[TOKEN_OPEN_FILEGLOB_BRACKET]) {
+            while (c != '>' && c != '<' && c != ';' && c != '\n' && !lexer->eof(lexer))
+              ADVANCE_C;
+            if (c == '>') {
+              lexerstate_push_quote(state, '<');
+              TOKEN(TOKEN_OPEN_FILEGLOB_BRACKET);
+            }
+          }
+          // not a readline, not a fileglob — let `<` fall through to the
+          // grammar as the relational operator.
+          return false;
       }
 
   }

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -246,6 +246,37 @@ EXPR < EXPR - list/non assoc
       (number))))
 
 ================================================================================
+bareword/sub term < EXPR is relational, not readline (gh#210)
+================================================================================
+die if CONST < 0;
+CONST < $y;
+CONST <= 0;
+CONST <FH>;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (postfix_conditional_expression
+      (bareword)
+      condition: (relational_expression
+        left: (bareword)
+        right: (number))))
+  (expression_statement
+    (relational_expression
+      left: (bareword)
+      right: (scalar
+        (varname))))
+  (expression_statement
+    (relational_expression
+      left: (bareword)
+      right: (number)))
+  (expression_statement
+    (ambiguous_function_call_expression
+      function: (function)
+      arguments: (readline_expression
+        (filehandle)))))
+
+================================================================================
 EXPR << EXPR
 ================================================================================
 1 << 2;


### PR DESCRIPTION
Closes #210.

`die if CONST < 0` produced an `(ERROR …)`, even though `die if CONST > 0` and `die if CONST() < 0` parse fine.

### Root cause

Only `<` can open a readline/fileglob quote-like, so `>` was never ambiguous. After a bareword, the readline/fileglob open token *is* legitimately valid — `CONST <FH>` means `CONST(<FH>)` — so on seeing `<` after `CONST` the scanner ran its lookahead: `<` + optional `$` + ident + `>` → readline; **anything else → fileglob, unconditionally**. For `CONST < 0` the `<` isn't a clean readline, so the scanner committed to `_open_fileglob_bracket`. Since an external token replaces the literal `<`, the relational-operator branch became unreachable, and the fileglob string parse then ran off the end of the statement → ERROR. `CONST() < 0` worked because the `)` ends the term, leaving `<` only ever the operator.

### Fix

A real fileglob is always `<…>` on one line. Before committing to `_open_fileglob_bracket`, the scanner now looks ahead (token end still covers only `<`, so this is pure lookahead) for a closing `>` before a statement boundary (`;`, newline, EOF; also stopping at a nested `<`). No `>` → `return false`, letting the grammar lex `<` as relational less-than. Also gates fileglob emission on `valid_symbols[...]`. ~22-line scanner-only change; no grammar/precedence changes.

### Verified still correct

`<>`, `<STDIN>`, `<ARGV>`, `<$fh>`, `<*.c>`, `<$dir/*.txt>`, `scalar <$sner>`, `while (<$fh>) {}`, `print STDERR <$fh>`, and `CONST <FH>` / `CONST <$fh>` (still `ambiguous_function_call_expression` with a `readline_expression` argument). New relational cases: `CONST < 0`, `CONST < $y`, `CONST <= 0`.

New corpus test in `test/corpus/operators`; existing diamond-operator test untouched. Suite: **220/220**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)