### PR TITLE
Fix sigil chars shadowing operators after a bareword (&& ** *= %= …)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -591,13 +591,15 @@ module.exports = grammar({
     assignment_expression: $ => prec.right(TERMPREC.ASSIGNOP,
       binop(
         choice( // _ASSIGNOP
-          '=', '**=',
+          // The compound-assigns starting with a sigil char (`*` `%` `&`) need
+          // higher lexer prec than the `*`/`%`/`&` sigils (`_GLOB_STAR`/
+          // `_HASH_PERCENT`/`_SUB_AMPER`, all prec 2) so that after a bareword in
+          // term position (`FOO **= 1`, `FOO %= 1`, `FOO &= 1`, …) the operator
+          // wins on longest-match instead of the leading sigil char being eaten
+          // as a `*glob`/`%hash`/`&sub` sigil (which orphaned the tail into ERROR).
+          '=', token(prec(2, '**=')),
           '+=', '-=', '.=',
-          '*=', '/=', '%=', 'x=',
-          // `&=`/`&&=` need higher lexer prec than the `&` sub sigil
-          // (`_SUB_AMPER`, prec 2) so that after a bareword in term position
-          // (`FOO &&= ...`, `FOO &= ...`) the operator wins instead of the
-          // leading `&` being eaten as a sub-call sigil.
+          token(prec(2, '*=')), '/=', token(prec(2, '%=')), 'x=',
           token(prec(2, '&=')), '|=', '^=',
           // TODO: Also &.= |.= ^.= when enabled
           '<<=', '>>=',
@@ -610,7 +612,9 @@ module.exports = grammar({
     binary_expression: $ => {
       const table = [
         [prec.right, binop.nonassoc, choice('..', '...'), TERMPREC.DOTDOT], // _DOTDOT
-        [prec.right, binop, '**', TERMPREC.POWOP], // _POWOP
+        // `**` needs higher lexer prec than the `*` glob sigil (`_GLOB_STAR`,
+        // prec 2) so `FOO ** 2` after a bareword isn't mis-lexed as a `*glob`.
+        [prec.right, binop, token(prec(2, '**')), TERMPREC.POWOP], // _POWOP
         [prec.left, binop, choice('||', '//', '^^'), TERMPREC.OROR], // _OROR_DORDOR
         // `&&` needs higher lexer prec than the `&` sub sigil (`_SUB_AMPER`,
         // prec 2) so that after a bareword in term position (`FOO && 1`) the

--- a/grammar.js
+++ b/grammar.js
@@ -594,10 +594,14 @@ module.exports = grammar({
           '=', '**=',
           '+=', '-=', '.=',
           '*=', '/=', '%=', 'x=',
-          '&=', '|=', '^=',
+          // `&=`/`&&=` need higher lexer prec than the `&` sub sigil
+          // (`_SUB_AMPER`, prec 2) so that after a bareword in term position
+          // (`FOO &&= ...`, `FOO &= ...`) the operator wins instead of the
+          // leading `&` being eaten as a sub-call sigil.
+          token(prec(2, '&=')), '|=', '^=',
           // TODO: Also &.= |.= ^.= when enabled
           '<<=', '>>=',
-          '&&=', '||=', '//=',
+          token(prec(2, '&&=')), '||=', '//=',
         ),
         $._term
       )
@@ -608,7 +612,11 @@ module.exports = grammar({
         [prec.right, binop.nonassoc, choice('..', '...'), TERMPREC.DOTDOT], // _DOTDOT
         [prec.right, binop, '**', TERMPREC.POWOP], // _POWOP
         [prec.left, binop, choice('||', '//', '^^'), TERMPREC.OROR], // _OROR_DORDOR
-        [prec.left, binop, '&&', TERMPREC.ANDAND], // _ANDAND
+        // `&&` needs higher lexer prec than the `&` sub sigil (`_SUB_AMPER`,
+        // prec 2) so that after a bareword in term position (`FOO && 1`) the
+        // logical-and operator wins instead of the leading `&` being eaten as
+        // a sub-call sigil (which orphaned the trailing `& 1` into an ERROR).
+        [prec.left, binop, token(prec(2, '&&')), TERMPREC.ANDAND], // _ANDAND
         [prec.left, binop, choice('|', '^'), TERMPREC.BITOROP], // _BITORDOP
         [prec.left, binop, '&', TERMPREC.BITANDOP], // _BITANDOP
         [prec.left, binop, choice('<<', '>>'), TERMPREC.SHIFTOP], // _SHIFTOP

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2959,8 +2959,15 @@
                   "value": "="
                 },
                 {
-                  "type": "STRING",
-                  "value": "**="
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "**="
+                    }
+                  }
                 },
                 {
                   "type": "STRING",
@@ -2975,16 +2982,30 @@
                   "value": ".="
                 },
                 {
-                  "type": "STRING",
-                  "value": "*="
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "*="
+                    }
+                  }
                 },
                 {
                   "type": "STRING",
                   "value": "/="
                 },
                 {
-                  "type": "STRING",
-                  "value": "%="
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "%="
+                    }
+                  }
                 },
                 {
                   "type": "STRING",
@@ -3151,8 +3172,15 @@
                 "type": "FIELD",
                 "name": "operator",
                 "content": {
-                  "type": "STRING",
-                  "value": "**"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "**"
+                    }
+                  }
                 }
               },
               {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2991,8 +2991,15 @@
                   "value": "x="
                 },
                 {
-                  "type": "STRING",
-                  "value": "&="
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "&="
+                    }
+                  }
                 },
                 {
                   "type": "STRING",
@@ -3011,8 +3018,15 @@
                   "value": ">>="
                 },
                 {
-                  "type": "STRING",
-                  "value": "&&="
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "&&="
+                    }
+                  }
                 },
                 {
                   "type": "STRING",
@@ -3216,8 +3230,15 @@
                 "type": "FIELD",
                 "name": "operator",
                 "content": {
-                  "type": "STRING",
-                  "value": "&&"
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "PREC",
+                    "value": 2,
+                    "content": {
+                      "type": "STRING",
+                      "value": "&&"
+                    }
+                  }
                 }
               },
               {

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -616,6 +616,37 @@ FOO &= 1;
       right: (number))))
 
 ================================================================================
+bareword/sub term ** *= %= are operators, not glob/hash sigils (gh#230 family)
+================================================================================
+my $x = FOO ** 2;
+FOO *= 2;
+FOO %= 2;
+FOO **= 2;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (assignment_expression
+      left: (variable_declaration
+        variable: (scalar
+          (varname)))
+      right: (binary_expression
+        left: (bareword)
+        right: (number))))
+  (expression_statement
+    (assignment_expression
+      left: (bareword)
+      right: (number)))
+  (expression_statement
+    (assignment_expression
+      left: (bareword)
+      right: (number)))
+  (expression_statement
+    (assignment_expression
+      left: (bareword)
+      right: (number))))
+
+================================================================================
 real amper-sub uses and bitwise & still parse (regression guard for gh#230 fix)
 ================================================================================
 &foo;

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -577,3 +577,102 @@ tr[$things] #@shtuff#cd <-- tricks! it's a comment
       (transliteration_content)
       (comment)
       (replacement))))
+
+================================================================================
+bareword/sub term && EXPR is logical-and, not amper-sub call (gh#230 family)
+================================================================================
+my $x = FOO && 1;
+CONST && $y;
+defined && 1;
+FOO &&= 1;
+FOO &= 1;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (assignment_expression
+      left: (variable_declaration
+        variable: (scalar
+          (varname)))
+      right: (binary_expression
+        left: (bareword)
+        right: (number))))
+  (expression_statement
+    (binary_expression
+      left: (bareword)
+      right: (scalar
+        (varname))))
+  (expression_statement
+    (binary_expression
+      left: (func1op_call_expression)
+      right: (number)))
+  (expression_statement
+    (assignment_expression
+      left: (bareword)
+      right: (number)))
+  (expression_statement
+    (assignment_expression
+      left: (bareword)
+      right: (number))))
+
+================================================================================
+real amper-sub uses and bitwise & still parse (regression guard for gh#230 fix)
+================================================================================
+&foo;
+&$ref;
+&{ $code };
+my $r = \&foo;
+my $x = $a & $b;
+$a && $b;
+FOO &foo;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (function_call_expression
+      function: (function
+        (varname))))
+  (expression_statement
+    (function_call_expression
+      function: (function
+        (varname
+          (scalar
+            (varname))))))
+  (expression_statement
+    (function_call_expression
+      function: (function
+        (varname
+          (block
+            (expression_statement
+              (scalar
+                (varname))))))))
+  (expression_statement
+    (assignment_expression
+      left: (variable_declaration
+        variable: (scalar
+          (varname)))
+      right: (refgen_expression
+        (function
+          (varname)))))
+  (expression_statement
+    (assignment_expression
+      left: (variable_declaration
+        variable: (scalar
+          (varname)))
+      right: (binary_expression
+        left: (scalar
+          (varname))
+        right: (scalar
+          (varname)))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (scalar
+        (varname))))
+  (expression_statement
+    (ambiguous_function_call_expression
+      function: (function)
+      arguments: (function_call_expression
+        function: (function
+          (varname))))))


### PR DESCRIPTION
A bareword/constant in term position followed by an operator whose first char is a sigil (`&`, `*`, `%`) was mis-parsed — the sigil char got lexed as the start of a `&sub`/`*glob`/`%hash` sigil, the bareword "called" it, and the tail orphaned into an `(ERROR)`. ~125 real-world modules hit this (it was the single biggest cluster of corpus parse failures).

```perl
my $x = FOO && 1;     # was: FOO(&...) + (ERROR 1)
my $x = FOO ** 2;     # was: FOO(*...) + (ERROR 2)
FOO *= 2;  FOO %= 2;  FOO &= 1;   # all ERROR'd
```
(`$a && FOO` etc. were always fine — only a bareword on the *left* triggers the sigil contention.)

### Root cause — lexer precedence, not grammar greed

The sigils are defined with explicit token precedence: `_SUB_AMPER`/`_GLOB_STAR`/`_HASH_PERCENT` = `token(prec(2, …))`. tree-sitter resolves competing lexer tokens by **explicit precedence first, longest-match second** — so the 1-char sigil (prec 2) beats the 2-/3-char operator (`&&`, `**`, `*=`, `%=`, `&&=`, `**=`, prec 0) even though the operator is the longer match. After a bareword both are valid (a bareword legitimately can take an `&sub` argument), so the sigil wins and the parse derails.

Same family as the merged #210 (`<`-as-fileglob after a bareword): a higher-priority special token shadowing the operator in term position.

### Fix

Bump the multi-char operators that *start with* a sigil char to `token(prec(2, …))`, so they tie the sigil on precedence and then win on longest-match:
- `&` family: `&&`, `&=`, `&&=`
- `*` family: `**`, `*=`, `**=`
- `%` family: `%=`

Safe because a sigil is never a *prefix* of these (a sigil is always followed by an indirob — identifier/`$`/`{`/special var). Single-char `*`/`%`/`&` operators are deliberately left alone — those are genuinely ambiguous with globs/hashes/subs after a bareword (`FOO &bar` really can mean `FOO(&bar)`), exactly as before.

### Verification
- Corpus: the affected cluster recovered **125 files**; a broad 1100-file sample showed **0 new failures** (+13 incidental fixes).
- Regression guards verified: `&foo`/`&$ref`/`&{…}`/`\&foo`, `*glob`/`*STDOUT{IO}`, `%hash`, `2 ** 3`, `$x **= 2`, `$a * $b`, `$a % $b`.
- New corpus tests for both the `&&` and `** *= %=` sub-families. **227/227** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)