### PR TITLE
Fix regex content starting with a delimiter-matching bracket (m{{…}})

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -124,17 +124,32 @@ static int32_t close_for_open(int32_t c) {
 
 typedef struct {
   int32_t open, close, count;
-  /* `body_col` is the column at which this quote's body begins (immediately
-   * after the opening delimiter).  It lets the scanner recognise a
-   * pattern-LEADING '['/'{' -- one with no variable in front of it -- where the
-   * S_intuit_more subscript heuristic has nothing to weigh and so must not be
-   * consulted.  Only meaningful when the bracket is on the body's first line
-   * with no whitespace before it; any intervening whitespace is detected
-   * separately (a subscript binds immediately, so whitespace rules it out). */
+  /* These two together recognise a pattern-LEADING '['/'{' -- the quote's own
+   * opening delimiter appearing as the literal first element of the body
+   * (m{{...}}, qr{ {...} }, s{{...}}, m[[...]]) -- where the S_intuit_more
+   * subscript heuristic has nothing to weigh and so must not be consulted.  A
+   * real subscript binds immediately to a preceding variable, so a bracket is
+   * leading iff only optional whitespace precedes it in the body.
+   *
+   * `body_col` is the column just after the opening delimiter, recorded once at
+   * the (committed) open token, so it is stable under GLR backtracking.  A
+   * bracket sitting at this column is at the body start -- but only on the
+   * opener's own line, since columns repeat across lines.
+   *
+   * `seen_content` records whether the body has consumed any real content yet.
+   * It disambiguates the cross-line column collision: a bracket reaching a
+   * later line must have crossed either whitespace (caught separately) or real
+   * content, and content sets this flag, so a later-line bracket that happens
+   * to land at `body_col` is correctly treated as non-leading.  (The flag is
+   * only durable when set by content that emits an external token -- literal
+   * text, escapes, nested delimiters -- but those are exactly the cases that
+   * could push a bracket onto a later column-colliding line, so that is enough;
+   * a bare leading `$var{...}` subscript is instead ruled out by `body_col`.) */
   int32_t body_col;
+  bool seen_content;
 } TSPQuote;
 
-static TSPQuote tspquote_new() { return (TSPQuote){0, 0, 0, -1}; }
+static TSPQuote tspquote_new() { return (TSPQuote){0, 0, 0, -1, false}; }
 
 enum HeredocState { HEREDOC_NONE, HEREDOC_START, HEREDOC_UNKNOWN, HEREDOC_CONTINUE, HEREDOC_END };
 typedef struct {
@@ -216,18 +231,25 @@ static void lexerstate_set_body_col(LexerState *state, int32_t col) {
   if (state->quotes.size) array_back(&state->quotes)->body_col = col;
 }
 
+/* Mark that the innermost quote's body has now consumed real content, so a
+ * later delimiter-matching bracket is a subscript candidate, not leading. */
+static void lexerstate_mark_content_seen(LexerState *state) {
+  if (state->quotes.size) array_back(&state->quotes)->seen_content = true;
+}
+
 /* Is the bracket at `col` (with `had_whitespace` describing whether any
  * whitespace was skipped before it) at the pattern-LEADING position of the
- * innermost quote -- i.e. only whitespace, if anything, precedes it?  A real
- * subscript binds immediately to its variable, so any preceding whitespace
- * rules a subscript out; otherwise the bracket is leading iff it sits exactly
- * at the body's start column. */
+ * innermost quote -- i.e. only whitespace, if anything, precedes it in this
+ * body?  A real subscript binds immediately to its variable, so any preceding
+ * whitespace rules a subscript out; otherwise the bracket is leading iff it
+ * sits at the body's start column AND no content has been seen yet (the latter
+ * rules out a same-column collision on a later line). */
 static bool lexerstate_at_body_lead(LexerState *state, int32_t col,
                                     bool had_whitespace) {
   if (!state->quotes.size) return false;
   TSPQuote *q = array_back(&state->quotes);
   if (q->body_col < 0) return false;
-  return had_whitespace || col == q->body_col;
+  return had_whitespace || (!q->seen_content && col == q->body_col);
 }
 
 //   in order to emulate a sublex, we basically need to have a new escape type character
@@ -747,6 +769,10 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
 
   if (valid_symbols[TOKEN_DOLLAR_IN_REGEXP] && c == '$') {
     DEBUG("Dollar in regexp\n", 0);
+    /* A '$' is body content (a variable / interpolation), so it ends the
+     * pattern-leading position: a following delimiter-matching bracket is now a
+     * subscript candidate, not a leading group. */
+    lexerstate_mark_content_seen(state);
     ADVANCE_C;
 
     /* Accept this literal dollar if it's followed by closing delimiter */
@@ -780,9 +806,13 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
      * count so the matching inner close doesn't terminate the quote early.
      * Anything beyond the leading position is genuinely ambiguous again, so the
      * heuristic below applies as before. */
-    if (lexerstate_at_body_lead(state, lexer->get_column(lexer),
-                                skipped_whitespace) &&
-        lexerstate_is_quote_opener(state, c)) {
+    bool leading = lexerstate_at_body_lead(state, lexer->get_column(lexer),
+                                           skipped_whitespace) &&
+                   lexerstate_is_quote_opener(state, c);
+    /* Either way this bracket is body content, so it ends the leading position
+     * for whatever follows it. */
+    lexerstate_mark_content_seen(state);
+    if (leading) {
       /* leave the opener for the content scanner below */
     } else {
     int32_t open = c;
@@ -949,8 +979,9 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     }
 
     lexerstate_push_quote(state, delim);
-    /* The body begins at the current column (just past the opener); record it
-     * so a bracket sitting exactly here is recognised as pattern-leading. */
+    /* Record the body's start column; combined with the (initially false)
+     * seen_content flag this recognises a bracket immediately following the
+     * opener as pattern-leading. */
     lexerstate_set_body_col(state, lexer->get_column(lexer));
     // TODO - fill in this debug print here?
     // DEBUG("Generic QSTRING open='%c' close='%c'\n", state->delim_open,
@@ -962,6 +993,8 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
       // If we're inside a quotelike that is using the `\` as a delimiter then
       // this doesn't count
       !(valid_symbols[TOKEN_QUOTELIKE_END] && lexerstate_is_quote_closer(state, '\\'))) {
+    /* An escape is body content, so it ends the pattern-leading position. */
+    lexerstate_mark_content_seen(state);
     // eat the reverse-solidus
     ADVANCE_C;
     // let's see what that reverse-solidus was hiding!
@@ -1022,6 +1055,16 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
   if (valid_symbols[TOKEN_Q_STRING_CONTENT] || valid_symbols[TOKEN_QQ_STRING_CONTENT]) {
     bool is_qq = valid_symbols[TOKEN_QQ_STRING_CONTENT];
     bool valid = false;
+
+    /* Any char here that is not the body-closing delimiter is body content
+     * (literal text, an interpolation sigil, an escape, or a nested opener),
+     * so the pattern-leading position is over.  The closing delimiter ends the
+     * body and is not content, so it must not mark. */
+    {
+      int32_t closer = lexerstate_is_quote_closer(state, c);
+      if (!(closer && lexerstate_is_quote_closed(state, closer)))
+        lexerstate_mark_content_seen(state);
+    }
 
     while (c) {
       if (c == '\\') break;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -124,32 +124,25 @@ static int32_t close_for_open(int32_t c) {
 
 typedef struct {
   int32_t open, close, count;
-  /* These two together recognise a pattern-LEADING '['/'{' -- the quote's own
-   * opening delimiter appearing as the literal first element of the body
-   * (m{{...}}, qr{ {...} }, s{{...}}, m[[...]]) -- where the S_intuit_more
-   * subscript heuristic has nothing to weigh and so must not be consulted.  A
-   * real subscript binds immediately to a preceding variable, so a bracket is
-   * leading iff only optional whitespace precedes it in the body.
+  /* Recognises a pattern-LEADING '['/'{' -- the quote's own opening delimiter
+   * appearing (after optional whitespace) as the literal first element of the
+   * body (m{{...}}, qr{ {...} }, s{{...}}, m[[...]]) -- where the S_intuit_more
+   * subscript heuristic (tsp_intuit_more) has no preceding variable to weigh and
+   * so must not be consulted.
    *
-   * `body_col` is the column just after the opening delimiter, recorded once at
-   * the (committed) open token, so it is stable under GLR backtracking.  A
-   * bracket sitting at this column is at the body start -- but only on the
-   * opener's own line, since columns repeat across lines.
+   * Decided ONCE by a bounded lookahead at the opening delimiter (see the open
+   * handler), where the lexer sits exactly at the body start: if the first
+   * non-space body char is the delimiter again, the body leads with a literal
+   * group.  Looking at the actual first char sidesteps both problems of the
+   * earlier column+flag scheme -- columns repeat across lines, and the scanner
+   * can't see grammar-lexed interpolation -- because we never have to ask "has
+   * content been seen?": we just check what the first char *is*.
    *
-   * `seen_content` records whether the body has consumed any real content yet.
-   * It disambiguates the cross-line column collision: a bracket reaching a
-   * later line must have crossed either whitespace (caught separately) or real
-   * content, and content sets this flag, so a later-line bracket that happens
-   * to land at `body_col` is correctly treated as non-leading.  (The flag is
-   * only durable when set by content that emits an external token -- literal
-   * text, escapes, nested delimiters -- but those are exactly the cases that
-   * could push a bracket onto a later column-colliding line, so that is enough;
-   * a bare leading `$var{...}` subscript is instead ruled out by `body_col`.) */
-  int32_t body_col;
-  bool seen_content;
+   * Set at the opener, consumed (cleared) by that first bracket. */
+  bool body_leads_with_delim;
 } TSPQuote;
 
-static TSPQuote tspquote_new() { return (TSPQuote){0, 0, 0, -1, false}; }
+static TSPQuote tspquote_new() { return (TSPQuote){0, 0, 0, false}; }
 
 enum HeredocState { HEREDOC_NONE, HEREDOC_START, HEREDOC_UNKNOWN, HEREDOC_CONTINUE, HEREDOC_END };
 typedef struct {
@@ -225,31 +218,18 @@ static bool lexerstate_is_paired_delimiter(LexerState *state) {
   return !!q->open;
 }
 
-/* Record where the innermost quote's body starts (the column just after its
- * opening delimiter), for pattern-leading bracket detection. */
-static void lexerstate_set_body_col(LexerState *state, int32_t col) {
-  if (state->quotes.size) array_back(&state->quotes)->body_col = col;
-}
-
-/* Mark that the innermost quote's body has now consumed real content, so a
- * later delimiter-matching bracket is a subscript candidate, not leading. */
-static void lexerstate_mark_content_seen(LexerState *state) {
-  if (state->quotes.size) array_back(&state->quotes)->seen_content = true;
-}
-
-/* Is the bracket at `col` (with `had_whitespace` describing whether any
- * whitespace was skipped before it) at the pattern-LEADING position of the
- * innermost quote -- i.e. only whitespace, if anything, precedes it in this
- * body?  A real subscript binds immediately to its variable, so any preceding
- * whitespace rules a subscript out; otherwise the bracket is leading iff it
- * sits at the body's start column AND no content has been seen yet (the latter
- * rules out a same-column collision on a later line). */
-static bool lexerstate_at_body_lead(LexerState *state, int32_t col,
-                                    bool had_whitespace) {
+/* Is `c` the innermost quote's pattern-leading bracket -- the delimiter-matching
+ * '['/'{' the open-handler lookahead flagged as the body's first literal element?
+ * One-shot: clears the flag so a later same-delimiter bracket is treated as
+ * ordinary (subscript/class) content. */
+static bool lexerstate_take_body_lead(LexerState *state, int32_t c) {
   if (!state->quotes.size) return false;
   TSPQuote *q = array_back(&state->quotes);
-  if (q->body_col < 0) return false;
-  return had_whitespace || (!q->seen_content && col == q->body_col);
+  if (q->body_leads_with_delim && c == q->open) {
+    q->body_leads_with_delim = false;
+    return true;
+  }
+  return false;
 }
 
 //   in order to emulate a sublex, we basically need to have a new escape type character
@@ -745,7 +725,6 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
 
     if (c != '/') {
       lexerstate_push_quote(state, '/');
-      lexerstate_set_body_col(state, lexer->get_column(lexer));
       TOKEN(TOKEN_SEARCH_SLASH);
     }
     /* if we didn't get a search-slash, we fall back to the main parser */
@@ -769,10 +748,6 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
 
   if (valid_symbols[TOKEN_DOLLAR_IN_REGEXP] && c == '$') {
     DEBUG("Dollar in regexp\n", 0);
-    /* A '$' is body content (a variable / interpolation), so it ends the
-     * pattern-leading position: a following delimiter-matching bracket is now a
-     * subscript candidate, not a leading group. */
-    lexerstate_mark_content_seen(state);
     ADVANCE_C;
 
     /* Accept this literal dollar if it's followed by closing delimiter */
@@ -806,12 +781,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
      * count so the matching inner close doesn't terminate the quote early.
      * Anything beyond the leading position is genuinely ambiguous again, so the
      * heuristic below applies as before. */
-    bool leading = lexerstate_at_body_lead(state, lexer->get_column(lexer),
-                                           skipped_whitespace) &&
-                   lexerstate_is_quote_opener(state, c);
-    /* Either way this bracket is body content, so it ends the leading position
-     * for whatever follows it. */
-    lexerstate_mark_content_seen(state);
+    bool leading = lexerstate_take_body_lead(state, c);
     if (leading) {
       /* leave the opener for the content scanner below */
     } else {
@@ -979,13 +949,16 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     }
 
     lexerstate_push_quote(state, delim);
-    /* Record the body's start column; combined with the (initially false)
-     * seen_content flag this recognises a bracket immediately following the
-     * opener as pattern-leading. */
-    lexerstate_set_body_col(state, lexer->get_column(lexer));
-    // TODO - fill in this debug print here?
-    // DEBUG("Generic QSTRING open='%c' close='%c'\n", state->delim_open,
-    // state->delim_close);
+    /* Pattern-leading bracket lookahead (see TSPQuote.body_leads_with_delim):
+     * for a paired delimiter, peek past any leading whitespace -- if the body's
+     * first real char is the delimiter again (m{{...}}, qr{ {...} }, m[[...]]),
+     * it's a literal leading group, not a subscript.  This is pure lookahead:
+     * MARK_END already covers just the opener, so these advances don't extend
+     * the emitted token and the body is re-scanned from the opener's end. */
+    if (close_for_open(delim)) {
+      while (is_tsp_whitespace(c)) ADVANCE_C;
+      if (c == delim) array_back(&state->quotes)->body_leads_with_delim = true;
+    }
     TOKEN(TOKEN_QUOTELIKE_BEGIN);
   }
 
@@ -993,8 +966,6 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
       // If we're inside a quotelike that is using the `\` as a delimiter then
       // this doesn't count
       !(valid_symbols[TOKEN_QUOTELIKE_END] && lexerstate_is_quote_closer(state, '\\'))) {
-    /* An escape is body content, so it ends the pattern-leading position. */
-    lexerstate_mark_content_seen(state);
     // eat the reverse-solidus
     ADVANCE_C;
     // let's see what that reverse-solidus was hiding!
@@ -1055,16 +1026,6 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
   if (valid_symbols[TOKEN_Q_STRING_CONTENT] || valid_symbols[TOKEN_QQ_STRING_CONTENT]) {
     bool is_qq = valid_symbols[TOKEN_QQ_STRING_CONTENT];
     bool valid = false;
-
-    /* Any char here that is not the body-closing delimiter is body content
-     * (literal text, an interpolation sigil, an escape, or a nested opener),
-     * so the pattern-leading position is over.  The closing delimiter ends the
-     * body and is not content, so it must not mark. */
-    {
-      int32_t closer = lexerstate_is_quote_closer(state, c);
-      if (!(closer && lexerstate_is_quote_closed(state, closer)))
-        lexerstate_mark_content_seen(state);
-    }
 
     while (c) {
       if (c == '\\') break;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -124,9 +124,17 @@ static int32_t close_for_open(int32_t c) {
 
 typedef struct {
   int32_t open, close, count;
+  /* `body_col` is the column at which this quote's body begins (immediately
+   * after the opening delimiter).  It lets the scanner recognise a
+   * pattern-LEADING '['/'{' -- one with no variable in front of it -- where the
+   * S_intuit_more subscript heuristic has nothing to weigh and so must not be
+   * consulted.  Only meaningful when the bracket is on the body's first line
+   * with no whitespace before it; any intervening whitespace is detected
+   * separately (a subscript binds immediately, so whitespace rules it out). */
+  int32_t body_col;
 } TSPQuote;
 
-static TSPQuote tspquote_new() { return (TSPQuote){0, 0, 0}; }
+static TSPQuote tspquote_new() { return (TSPQuote){0, 0, 0, -1}; }
 
 enum HeredocState { HEREDOC_NONE, HEREDOC_START, HEREDOC_UNKNOWN, HEREDOC_CONTINUE, HEREDOC_END };
 typedef struct {
@@ -200,6 +208,26 @@ static void lexerstate_pop_quote(LexerState *state, int32_t idx) {
 static bool lexerstate_is_paired_delimiter(LexerState *state) {
   TSPQuote *q = array_back(&state->quotes);
   return !!q->open;
+}
+
+/* Record where the innermost quote's body starts (the column just after its
+ * opening delimiter), for pattern-leading bracket detection. */
+static void lexerstate_set_body_col(LexerState *state, int32_t col) {
+  if (state->quotes.size) array_back(&state->quotes)->body_col = col;
+}
+
+/* Is the bracket at `col` (with `had_whitespace` describing whether any
+ * whitespace was skipped before it) at the pattern-LEADING position of the
+ * innermost quote -- i.e. only whitespace, if anything, precedes it?  A real
+ * subscript binds immediately to its variable, so any preceding whitespace
+ * rules a subscript out; otherwise the bracket is leading iff it sits exactly
+ * at the body's start column. */
+static bool lexerstate_at_body_lead(LexerState *state, int32_t col,
+                                    bool had_whitespace) {
+  if (!state->quotes.size) return false;
+  TSPQuote *q = array_back(&state->quotes);
+  if (q->body_col < 0) return false;
+  return had_whitespace || col == q->body_col;
 }
 
 //   in order to emulate a sublex, we basically need to have a new escape type character
@@ -695,6 +723,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
 
     if (c != '/') {
       lexerstate_push_quote(state, '/');
+      lexerstate_set_body_col(state, lexer->get_column(lexer));
       TOKEN(TOKEN_SEARCH_SLASH);
     }
     /* if we didn't get a search-slash, we fall back to the main parser */
@@ -743,6 +772,19 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
    * takes over. */
   if ((valid_symbols[TOKEN_REGEXP_OPEN_BRACKET] && c == '[') ||
       (valid_symbols[TOKEN_REGEXP_OPEN_BRACE] && c == '{')) {
+    /* A pattern-LEADING '['/'{' that is the quote's own opening delimiter is a
+     * balanced nested delimiter (m{{...}}, qr{ {...} }, s{{...}}, m[[...]]),
+     * NOT a subscript: there is no preceding variable for intuit_more to weigh,
+     * and its subscript verdict here would be meaningless.  Fall through to the
+     * Q/QQ content scanner, which consumes the opener while tracking the nesting
+     * count so the matching inner close doesn't terminate the quote early.
+     * Anything beyond the leading position is genuinely ambiguous again, so the
+     * heuristic below applies as before. */
+    if (lexerstate_at_body_lead(state, lexer->get_column(lexer),
+                                skipped_whitespace) &&
+        lexerstate_is_quote_opener(state, c)) {
+      /* leave the opener for the content scanner below */
+    } else {
     int32_t open = c;
     int32_t close = (open == '[') ? ']' : '}';
 
@@ -769,6 +811,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     }
     /* subscript: let the grammar's immediate '[' / '{' win */
     return false;
+    }
   }
 
   if (valid_symbols[TOKEN_POD]) {
@@ -906,6 +949,9 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     }
 
     lexerstate_push_quote(state, delim);
+    /* The body begins at the current column (just past the opener); record it
+     * so a bracket sitting exactly here is recognised as pattern-leading. */
+    lexerstate_set_body_col(state, lexer->get_column(lexer));
     // TODO - fill in this debug print here?
     // DEBUG("Generic QSTRING open='%c' close='%c'\n", state->delim_open,
     // state->delim_close);

--- a/test/corpus/regexp
+++ b/test/corpus/regexp
@@ -383,3 +383,34 @@ $x =~ m{$h{k}};
             hash: (container_variable
               (varname))
             key: (autoquoted_bareword)))))))
+
+================================================================================
+multi-line pattern: subscript bracket at the body's start column on a later line
+================================================================================
+$x =~ m{aaaaaa
+bbbbbb$h{k}};
+$x =~ m[aaaaaa
+bbbbbb$a[0]];
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content
+          (hash_element_expression
+            hash: (container_variable
+              (varname))
+            key: (autoquoted_bareword))))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content
+          (array_element_expression
+            array: (container_variable
+              (varname))
+            index: (number)))))))

--- a/test/corpus/regexp
+++ b/test/corpus/regexp
@@ -293,3 +293,93 @@ y[abc]{xyz};
     (transliteration_expression
       (transliteration_content)
       (replacement))))
+
+================================================================================
+regex pattern-leading brace is a literal delimiter group, not a subscript
+================================================================================
+$x =~ m{{nested}};
+$x =~ m{ {n} };
+$x =~ qr{ {n} };
+$x =~ m[[x]];
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (quoted_regexp
+        content: (regexp_content))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content)))))
+
+================================================================================
+substitution with pattern-leading brace in pattern and replacement
+================================================================================
+$x =~ s{{{{a}}}}{b};
+$x =~ s{ {a} }{ {b} };
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (substitution_regexp
+        content: (regexp_content)
+        (replacement))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (substitution_regexp
+        content: (regexp_content)
+        (replacement)))))
+
+================================================================================
+regex bracket disambiguation still applies after content (#217 guard)
+================================================================================
+$x =~ m{[abc]};
+$x =~ m{a{2,3}};
+$x =~ m{$h{k}};
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content))))
+  (expression_statement
+    (binary_expression
+      left: (scalar
+        (varname))
+      right: (match_regexp
+        content: (regexp_content
+          (hash_element_expression
+            hash: (container_variable
+              (varname))
+            key: (autoquoted_bareword)))))))


### PR DESCRIPTION
## The bug

A brace/bracket-delimited regex whose content **starts** with a bracket equal to its own opening delimiter — `m{{nested}}`, `m{ {n} }`, `s{ {a} }{ {b} }`, `m[[x]]` — was rejected as `ERROR`/`MISSING`. All are valid Perl. Pre-existing (from the #217/#228 regex-bracket disambiguation).

## Root cause

The scanner routes a content-initial `{`/`[` through `tsp_intuit_more()` — our port of Perl's `S_intuit_more`, the `$var[…]` / `$var{…}` **subscript-vs-charclass** heuristic. That heuristic only makes sense immediately after an interpolated variable; at a pattern-**leading** position there is no preceding variable, so its verdict is meaningless and it misfired.

Perl never hits this: bracketing delimiters *nest*, so its delimiter scanner consumes the balanced leading `{…}` as raw body content **before** the regex compiler — and its `S_intuit_more` — ever looks at it. The "leading" carve-out just makes us match Perl: don't ask the subscript question where there's no variable to subscript.

## The fix: an open-time lookahead

When the scanner emits the opening delimiter, the lexer is sitting exactly at the body start. So we peek **once**: skip leading whitespace, and if the body's first real char is the delimiter again, the body leads with a literal group and we bypass the subscript heuristic. Pure lookahead (`mark_end` already covers the opener, so the body is re-scanned normally) — the same pattern the fileglob `<…>` disambiguation uses.

## Why the first approach was thrown out

The initial cut tracked a per-quote **body-start column** plus a **`seen_content` flag** — two imperfect signals patching each other's blind spots:

- a content flag alone is unreliable, because interpolation (`m{$h{k}}`) is lexed by the **grammar**, not the scanner, so "have we seen content?" stays false even when there *is* content → the **column** was needed to reject same-line subscripts;
- a column alone collides across lines (columns repeat), so a later-line bracket landing at the body-start column would false-positive → the **flag** was needed to reject that.

Two mechanisms, because neither the scanner's positional info nor its content-visibility is complete — which is exactly why it read as ugly. The lookahead removes the need for both: by inspecting **what the first body char actually is**, there's no column (no cross-line collision) and no inference from content-history (interpolation's invisibility to the scanner is irrelevant). One `bool` set in one place replaces an `int32_t` + a `bool` + three helpers + four scattered `mark_content_seen` calls + the extra serialized state (**−39 lines**), and the decision collapses to `flag && c == open`. It now reads the way you'd describe the rule.

## Verification

- New corpus tests: pattern-leading literal group (`m{{nested}}`, `m{ {n} }`, `qr{ {n} }`, `m[[x]]`), substitution leading brace in pattern + replacement (`s{{{{a}}}}{b}`, `s{ {a} }{ {b} }`), the multi-line cross-line case (`m{aaaaaa⏎bbbbbb$h{k}}`), and #217 regression guards (`m{[abc]}`, `m{a{2,3}}`, `m{$h{k}}` → `hash_element_expression`).
- **228/228** parses + all highlight assertions. **Zero** new failures / regressions across the 7731-file installed-module corpus.
- Out of scope (pre-existing, untouched): `m{\w{2}}` — a `{2}` quantifier directly after an escape sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
