### PR TITLE
[hybrid] glob-shape gate + post-`>` orphan lookahead (fileglob vs `<`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/*
 !src/grammar.json
 tree-sitter-perl.wasm
 log.html
+!src/tsp_intuit_readline.h

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -715,9 +715,18 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
           MARK_END;
           // ah, we have a heredoc; let's just go down to that section then
           if (c == '<') goto heredoc_token_handling;
-          if (c == '$') ADVANCE_C;
+          // Gather the `<...>` body as we go, starting right after `<`, so the
+          // fileglob content heuristic below sees the WHOLE body -- including
+          // the `$ident` prefix the readline probe consumes here (otherwise a
+          // `<$sner >` glob would reach the heuristic with content " ").
+          char content[256];
+          size_t clen = 0;
+          if (c == '$') { content[clen++] = '$'; ADVANCE_C; }
           // we now zoooom as many ident chars as we can
-          while (isidcont(c)) ADVANCE_C;
+          while (isidcont(c)) {
+            if (clen < sizeof(content)) content[clen++] = (c < 0x80) ? (char)c : (char)0x7f;
+            ADVANCE_C;
+          }
           // if ident chars took us until the closing `>` then we're readline FILEHANDLE
           if (c == '>') TOKEN(TOKEN_OPEN_READLINE_BRACKET);
           // otherwise we *might* be a fileglob operator (`<*.c>`, `<$dir/*>`).
@@ -757,8 +766,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
             // whole decision.  These advances are pure lookahead past MARK_END;
             // the emitted token stays exactly the one-char `<`.  Non-ASCII
             // collapses to a 0x7f placeholder (the heuristic is ASCII-only).
-            char content[256];
-            size_t clen = 0;
+            // `content`/`clen` already hold the `$ident` prefix gathered above.
             // The content scan stops at a statement boundary too, so we never
             // run off into the next line looking for a `>` that isn't there.
             while (c != '>' && c != '<' && c != ';' && c != '\n' &&

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3,6 +3,7 @@
 #include "tsp_unicode.h"
 #include "tsp_keywords.h"
 #include "tsp_intuit_more.h"
+#include "tsp_intuit_readline.h"
 
 // grumble grumble no stdlib
 static char *tsp_strchr(register const char *s, int c) {
@@ -749,46 +750,36 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
           // is parser state the scanner doesn't have.  We bias toward the
           // relational reading for such (contrived) inputs.
           if (valid_symbols[TOKEN_OPEN_FILEGLOB_BRACKET]) {
-            // tracks the start-of-word position so we can test whitespace-
-            // delimited tokens against the infix-operator list as we go
-            char word[4];
-            unsigned wlen = 0;
-            bool at_word_start = true;  // true after whitespace / right after `<`
-            bool saw_relational_op = false;
-            while (c != '>' && c != '<' && c != ';' && c != '\n' && !lexer->eof(lexer)) {
-              if (iswspace(c)) {
-                // a freshly-finished word: check it against the operators
-                if (wlen && wlen < sizeof(word)) {
-                  word[wlen] = '\0';
-                  if (streq(word, "and") || streq(word, "or") ||
-                      streq(word, "xor") || streq(word, "not") ||
-                      streq(word, "cmp") || streq(word, "eq") ||
-                      streq(word, "ne") || streq(word, "lt") ||
-                      streq(word, "gt") || streq(word, "le") ||
-                      streq(word, "ge") || streq(word, "x")) {
-                    saw_relational_op = true;
-                    break;
-                  }
-                }
-                wlen = 0;
-                at_word_start = true;
-              } else {
-                // only accumulate alpha runs that began at a word boundary;
-                // anything else (sigils, `*`, `/`, digits, `.`) makes this not
-                // a bare operator word, so we stop collecting until the next
-                // whitespace resets us
-                if (at_word_start && iswalpha((wint_t)c) && wlen < sizeof(word) - 1)
-                  word[wlen++] = (char)c;
-                else {
-                  wlen = sizeof(word);  // poison: too long / not a clean word
-                  at_word_start = false;
-                }
-              }
+            // Gather the `<...>` content (everything after `<` up to but not
+            // including the closing `>`) and a small window of the bytes that
+            // FOLLOW the `>` into capped buffers, then hand both to
+            // tsp_is_fileglob() (src/tsp_intuit_readline.h), which owns the
+            // whole decision.  These advances are pure lookahead past MARK_END;
+            // the emitted token stays exactly the one-char `<`.  Non-ASCII
+            // collapses to a 0x7f placeholder (the heuristic is ASCII-only).
+            char content[256];
+            size_t clen = 0;
+            // The content scan stops at a statement boundary too, so we never
+            // run off into the next line looking for a `>` that isn't there.
+            while (c != '>' && c != '<' && c != ';' && c != '\n' &&
+                   !lexer->eof(lexer)) {
+              if (clen < sizeof(content))
+                content[clen++] = (c < 0x80) ? (char)c : (char)0x7f;
               ADVANCE_C;
             }
-            if (c == '>' && !saw_relational_op) {
-              lexerstate_push_quote(state, '<');
-              TOKEN(TOKEN_OPEN_FILEGLOB_BRACKET);
+
+            if (c == '>') {
+              ADVANCE_C;  // step past the closing `>` (still pure lookahead)
+              char after[256];
+              size_t alen = 0;
+              while (alen < sizeof(after) && c != '\n' && !lexer->eof(lexer)) {
+                after[alen++] = (c < 0x80) ? (char)c : (char)0x7f;
+                ADVANCE_C;
+              }
+              if (tsp_is_fileglob(content, clen, after, alen)) {
+                lexerstate_push_quote(state, '<');
+                TOKEN(TOKEN_OPEN_FILEGLOB_BRACKET);
+              }
             }
           }
           // not a readline, not a fileglob — let `<` fall through to the

--- a/src/tsp_intuit_readline.h
+++ b/src/tsp_intuit_readline.h
@@ -1,0 +1,160 @@
+/* tsp_intuit_readline.h
+ *
+ * A tree-sitter-specific heuristic for the fileglob-vs-relational-operator
+ * ambiguity.  This is NOT a port of any perl routine: real perl resolves it
+ * purely by PL_expect (whether a value or a list operator preceded the `<`),
+ * which the external scanner cannot see.  Instead we use a content + trailing
+ * lookahead heuristic.
+ *
+ * The scanner reaches this decision only after an *ambiguous bareword*
+ * (`valid_symbols[TOKEN_OPEN_FILEGLOB_BRACKET]`) followed by `<...>` whose
+ * content is not a plain readline filehandle.  Both readings are syntactically
+ * live:
+ *
+ *   print <*.c>;        # glob:       `<` opens a fileglob
+ *   CONST < 7 > $x;     # relational: `<` is the less-than operator
+ *
+ * KEY STRUCTURAL INSIGHT ("post-`>` orphan lookahead"):
+ *   A real glob/readline `<...>` is a COMPLETE term.  After its closing `>`,
+ *   the surrounding `bareword <glob>` expression is itself a complete term, so
+ *   what follows the `>` must be an operator, a comma, a statement modifier /
+ *   low-precedence operator keyword, a closing bracket, `;`, newline, or EOF —
+ *   NOT another bare term.  In `CONST < 7 > $x` there is exactly one `>`, and
+ *   committing `< 7 >` as a glob would leave `$x` as an orphaned bare term with
+ *   no connecting operator.  That orphan is the proof that `<` was really the
+ *   relational operator (a chained comparison `CONST < 7 > $x`), so we bail.
+ *
+ * Decision (given the `<...>` content and the bytes following the `>`):
+ *   1. If the content contains a whitespace-delimited infix word-operator
+ *      (and/or/xor/not/cmp/eq/ne/lt/gt/le/ge/x) the `<...>` is a relational
+ *      expression, not a glob -> bail (NOT a fileglob).
+ *   2. Otherwise look at the first non-space byte AFTER the `>`:
+ *        - operator / comma / `;` / `=` / `=>` / closing bracket `) ] }` /
+ *          newline / EOF, or a statement-modifier / low-prec operator keyword
+ *          (if unless while until for foreach and or xor not cmp eq ne lt gt
+ *          le ge x)  -> the glob is a complete term -> FILEGLOB ok.
+ *        - a bare-term opener: a sigil (`$ @ %`), a digit, a quote (`" '`), or
+ *          an opening bracket that would start a fresh term (`( [ {`)  ->
+ *          orphaned term -> bail (NOT a fileglob).
+ *        - an alphabetic word that is NOT one of the keywords above: AMBIGUOUS.
+ *          We lean toward NOT orphaning (treat as a fileglob) so that code like
+ *          `<glob> SOMEFUNC` / `print <*.c> LIST` keeps parsing as a glob.  In
+ *          practice a glob followed by a bareword is far more common (and less
+ *          broken) than the relational `CONST < x > word` shape, and breaking a
+ *          glob produces a cascading ERROR whereas the contrived relational
+ *          chain ending in a bareword does not.
+ *
+ * tsp_is_fileglob(content, clen, after, alen) returns TRUE  => commit to the
+ * fileglob (subject to the scanner's other checks, e.g. a closing `>` was
+ * actually found); FALSE => bail so `<` lexes as the relational operator.
+ *
+ * Limitation: `after` is only a small buffered window (the scanner caps it at
+ * ~256 bytes) of the bytes following the `>`.  If the buffer ends before any
+ * non-space byte (extremely long whitespace run / EOF-in-window) we treat it as
+ * EOF-like and allow the glob.  Like the whole routine, this is best-effort and
+ * an LSP with full parser state can refine it.  Never reads past the buffers.
+ */
+
+#ifndef TSP_INTUIT_READLINE_H
+#define TSP_INTUIT_READLINE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+/* --- ASCII classification (mirrors the subset used elsewhere) -------------- */
+static inline bool tsp_rl_isdigit(int c) { return c >= '0' && c <= '9'; }
+static inline bool tsp_rl_isalpha(int c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+static inline bool tsp_rl_isword(int c) {
+  return tsp_rl_isalpha(c) || tsp_rl_isdigit(c) || c == '_';
+}
+static inline bool tsp_rl_isspace(int c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+         c == '\v';
+}
+
+/* The low-precedence operator / statement-modifier keywords that may legally
+ * FOLLOW a complete `bareword <glob>` term.  Seeing one of these after the `>`
+ * means the glob is complete, not orphaning a term. */
+static inline bool tsp_rl_is_trailing_keyword(const char *w, size_t n) {
+  static const char *const kw[] = {
+      "if", "unless", "while", "until", "for", "foreach", "and", "or", "xor",
+      "not", "cmp", "eq", "ne", "lt", "gt", "le", "ge", "x"};
+  for (size_t i = 0; i < sizeof(kw) / sizeof(kw[0]); i++) {
+    if (strlen(kw[i]) == n && memcmp(w, kw[i], n) == 0) return true;
+  }
+  return false;
+}
+
+/* The infix word-operators that, when appearing INSIDE the `<...>` content as a
+ * whitespace-delimited word, prove it is a relational expression rather than a
+ * glob pattern (a glob never contains a bare perl operator word). */
+static inline bool tsp_rl_is_infix_word(const char *w, size_t n) {
+  static const char *const kw[] = {"and", "or", "xor", "not", "cmp", "eq",
+                                    "ne",  "lt", "gt",  "le",  "ge",  "x"};
+  for (size_t i = 0; i < sizeof(kw) / sizeof(kw[0]); i++) {
+    if (strlen(kw[i]) == n && memcmp(w, kw[i], n) == 0) return true;
+  }
+  return false;
+}
+
+/* Scan the `<...>` content for a whitespace-delimited infix operator word.
+ * Only alpha runs that start at a whitespace boundary (and are not glued to
+ * sigils/digits/punctuation) count; `$x` or `*.c` never qualify. */
+static inline bool tsp_rl_content_has_infix_op(const char *s, size_t len) {
+  size_t i = 0;
+  while (i < len) {
+    /* skip leading whitespace */
+    while (i < len && tsp_rl_isspace((unsigned char)s[i])) i++;
+    size_t start = i;
+    bool clean = true;  /* a clean bare word: only alphas */
+    while (i < len && !tsp_rl_isspace((unsigned char)s[i])) {
+      if (!tsp_rl_isalpha((unsigned char)s[i])) clean = false;
+      i++;
+    }
+    if (clean && i > start && tsp_rl_is_infix_word(s + start, i - start))
+      return true;
+  }
+  return false;
+}
+
+/* --- the decision ---------------------------------------------------------- */
+static inline bool tsp_is_fileglob(const char *content, size_t clen,
+                                   const char *after, size_t alen) {
+  /* (1) operator-word inside the content => relational expression, not glob. */
+  if (tsp_rl_content_has_infix_op(content, clen)) return false;
+
+  /* (2) post-`>` orphan lookahead. */
+  size_t i = 0;
+  while (i < alen && tsp_rl_isspace((unsigned char)after[i])) i++;
+
+  /* Window exhausted before any non-space byte: treat as EOF-like -> glob ok. */
+  if (i >= alen) return true;
+
+  unsigned char nc = (unsigned char)after[i];
+
+  /* An alphabetic word: keyword => complete term (glob ok); otherwise an
+   * ambiguous bareword, which we lean toward NOT treating as an orphan. */
+  if (tsp_rl_isalpha(nc)) {
+    size_t start = i;
+    while (i < alen && tsp_rl_isword((unsigned char)after[i])) i++;
+    if (tsp_rl_is_trailing_keyword(after + start, i - start)) return true;
+    /* Unknown bareword after the glob: lean toward glob (do not orphan). */
+    return true;
+  }
+
+  /* Bare-term openers with no connecting operator => orphan => bail. */
+  if (nc == '$' || nc == '@' || nc == '%' || nc == '"' || nc == '\'' ||
+      tsp_rl_isdigit(nc) || nc == '(' || nc == '[' || nc == '{') {
+    return false;
+  }
+
+  /* Everything else — operators (`+ - * / . < > ! ~ ? : | & ^`), `=`, `=>`,
+   * comma, `;`, closing brackets `) ] }` — terminates the term cleanly, so the
+   * glob is complete. */
+  return true;
+}
+
+#endif /* TSP_INTUIT_READLINE_H */

--- a/src/tsp_intuit_readline.h
+++ b/src/tsp_intuit_readline.h
@@ -3,8 +3,8 @@
  * A tree-sitter-specific heuristic for the fileglob-vs-relational-operator
  * ambiguity.  This is NOT a port of any perl routine: real perl resolves it
  * purely by PL_expect (whether a value or a list operator preceded the `<`),
- * which the external scanner cannot see.  Instead we use a content + trailing
- * lookahead heuristic.
+ * which the external scanner cannot see.  Instead we use a HYBRID of a content
+ * shape test and a trailing-context (orphan) lookahead.
  *
  * The scanner reaches this decision only after an *ambiguous bareword*
  * (`valid_symbols[TOKEN_OPEN_FILEGLOB_BRACKET]`) followed by `<...>` whose
@@ -14,21 +14,29 @@
  *   print <*.c>;        # glob:       `<` opens a fileglob
  *   CONST < 7 > $x;     # relational: `<` is the less-than operator
  *
- * KEY STRUCTURAL INSIGHT ("post-`>` orphan lookahead"):
- *   A real glob/readline `<...>` is a COMPLETE term.  After its closing `>`,
- *   the surrounding `bareword <glob>` expression is itself a complete term, so
- *   what follows the `>` must be an operator, a comma, a statement modifier /
- *   low-precedence operator keyword, a closing bracket, `;`, newline, or EOF —
- *   NOT another bare term.  In `CONST < 7 > $x` there is exactly one `>`, and
- *   committing `< 7 >` as a glob would leave `$x` as an orphaned bare term with
- *   no connecting operator.  That orphan is the proof that `<` was really the
- *   relational operator (a chained comparison `CONST < 7 > $x`), so we bail.
+ * TWO INSIGHTS, COMBINED (each alone has a blind spot the other covers):
+ *
+ *   (a) GLOB-SHAPE.  A real glob/readline target positively LOOKS like one: a
+ *       glob pattern (metachar `*?[]{}~`, path `/`, or a filename-dot `foo.c`)
+ *       or a pure filehandle name (`$fh`, `STDIN`).  Content that is neither --
+ *       a bare number (`< 7 >`), a lone scalar with a separating space
+ *       (`< $a > foo`), an arithmetic operand -- is a relational operand, not a
+ *       glob.  This alone keeps `CONST < $a > foo` relational (a case a pure
+ *       orphan-lookahead gets wrong, since the trailing bareword looks benign).
+ *
+ *   (b) POST-`>` ORPHAN LOOKAHEAD.  A real glob is a COMPLETE term, so what
+ *       follows its `>` must be an operator, comma, statement modifier / low-
+ *       prec keyword, closing bracket, `;`, newline, or EOF -- NOT another bare
+ *       term.  In `CONST < $a/$b > $c` the content `$a/$b` IS glob-shaped (it
+ *       has a `/`), yet the trailing `$c` would be orphaned -- proof that `<`
+ *       was the operator (a case a pure content test gets wrong).
  *
  * Decision (given the `<...>` content and the bytes following the `>`):
- *   1. If the content contains a whitespace-delimited infix word-operator
- *      (and/or/xor/not/cmp/eq/ne/lt/gt/le/ge/x) the `<...>` is a relational
- *      expression, not a glob -> bail (NOT a fileglob).
- *   2. Otherwise look at the first non-space byte AFTER the `>`:
+ *   1. Content contains a whitespace-delimited infix word-operator
+ *      (and/or/xor/not/cmp/eq/ne/lt/gt/le/ge/x) => relational, bail.
+ *   2. Content is NOT glob-shaped and NOT a pure filehandle name => relational
+ *      operand, bail.  (the glob-shape gate, insight (a))
+ *   3. Otherwise look at the first non-space byte AFTER the `>` (insight (b)):
  *        - operator / comma / `;` / `=` / `=>` / closing bracket `) ] }` /
  *          newline / EOF, or a statement-modifier / low-prec operator keyword
  *          (if unless while until for foreach and or xor not cmp eq ne lt gt
@@ -38,11 +46,9 @@
  *          orphaned term -> bail (NOT a fileglob).
  *        - an alphabetic word that is NOT one of the keywords above: AMBIGUOUS.
  *          We lean toward NOT orphaning (treat as a fileglob) so that code like
- *          `<glob> SOMEFUNC` / `print <*.c> LIST` keeps parsing as a glob.  In
- *          practice a glob followed by a bareword is far more common (and less
- *          broken) than the relational `CONST < x > word` shape, and breaking a
- *          glob produces a cascading ERROR whereas the contrived relational
- *          chain ending in a bareword does not.
+ *          `<glob> SOMEFUNC` / `print <*.c> LIST` keeps parsing as a glob.  The
+ *          content already passed the glob-shape gate here, so leaning glob is
+ *          safer than orphaning a genuine glob.
  *
  * tsp_is_fileglob(content, clen, after, alen) returns TRUE  => commit to the
  * fileglob (subject to the scanner's other checks, e.g. a closing `>` was
@@ -120,13 +126,93 @@ static inline bool tsp_rl_content_has_infix_op(const char *s, size_t len) {
   return false;
 }
 
+/* The glob metacharacters whose presence in the content is decisive evidence
+ * of a glob pattern (as opposed to a relational operand). */
+static inline bool tsp_rl_is_glob_meta(int c) {
+  return c == '*' || c == '?' || c == '[' || c == ']' || c == '{' || c == '}' ||
+         c == '~';
+}
+
+/* Does the content POSITIVELY look like a glob pattern?  True if it contains a
+ * glob metacharacter, a path separator `/`, or a filename-looking `.` (a dot
+ * flanked by word characters, e.g. `foo.c`).  A bare number (`7`), a lone
+ * scalar (`$a`), or an operator expression has none of these. */
+static inline bool tsp_rl_content_is_globshaped(const char *s, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    unsigned char c = (unsigned char)s[i];
+    if (tsp_rl_is_glob_meta(c) || c == '/') return true;
+    if (c == '.') {
+      bool prev_word = (i > 0) && tsp_rl_isword((unsigned char)s[i - 1]);
+      bool next_word = (i + 1 < len) && tsp_rl_isword((unsigned char)s[i + 1]);
+      if (prev_word && next_word) return true;
+    }
+  }
+  return false;
+}
+
+/* Is the content a pure filehandle / scalar NAME (no leading whitespace): an
+ * optional leading `$`, then word characters with `::` or `'` package
+ * separators (e.g. `$fh`, `STDIN`, `Foo::BAR`), tolerating only trailing
+ * whitespace?  Such content is a readline target, not a relational operand.
+ * The leading-vs-trailing whitespace asymmetry is load-bearing: a glob target
+ * is written tight against `<` (`<$sner >`), whereas a relational `< EXPR`
+ * carries a separating space (`< $a > $b`). */
+static inline bool tsp_rl_is_filehandle(const char *buf, size_t len) {
+  size_t i = 0;
+  if (i >= len || tsp_rl_isspace((unsigned char)buf[i])) return false;
+  if (buf[i] == '$') i++;
+  if (i >= len) return false; /* bare `$`: not a name */
+
+  bool last_was_word = false;
+  while (i < len) {
+    if (tsp_rl_isword((unsigned char)buf[i])) {
+      last_was_word = true;
+      i++;
+    } else if (buf[i] == ':') {
+      if (!last_was_word) return false;
+      if (i + 1 >= len || buf[i + 1] != ':') return false;
+      last_was_word = false;
+      i += 2;
+    } else if (buf[i] == '\'') {
+      if (!last_was_word) return false;
+      last_was_word = false;
+      i++;
+    } else if (tsp_rl_isspace((unsigned char)buf[i])) {
+      if (!last_was_word) return false;
+      for (i++; i < len; i++)
+        if (!tsp_rl_isspace((unsigned char)buf[i])) return false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  return last_was_word;
+}
+
 /* --- the decision ---------------------------------------------------------- */
 static inline bool tsp_is_fileglob(const char *content, size_t clen,
                                    const char *after, size_t alen) {
+  /* The empty diamond `<>` (rare here; usually handled before us). */
+  if (clen == 0) return true;
+
   /* (1) operator-word inside the content => relational expression, not glob. */
   if (tsp_rl_content_has_infix_op(content, clen)) return false;
 
-  /* (2) post-`>` orphan lookahead. */
+  /* (2) GLOB-SHAPE GATE.  A real glob/readline target positively looks like a
+   * glob pattern (metachar / path / filename-dot) or a pure filehandle name.
+   * Content that is neither -- a bare number (`< 7 >`), a lone scalar with a
+   * separating space (`< $a > $b`), an arithmetic sub-expression -- is a
+   * relational operand, so bail.  This is what keeps `CONST < $a > foo` and
+   * `CONST < 7 > $x` relational without any lookahead. */
+  if (!tsp_rl_content_is_globshaped(content, clen) &&
+      !tsp_rl_is_filehandle(content, clen))
+    return false;
+
+  /* (3) post-`>` orphan lookahead.  The content looks glob-shaped, but a real
+   * glob is a COMPLETE term: if a bare term follows the `>` with no connecting
+   * operator it would be orphaned, which means `<` was the relational operator
+   * after all (e.g. `CONST < $a/$b > $c` -- glob-shaped content `$a/$b`, yet
+   * the trailing `$c` orphans). */
   size_t i = 0;
   while (i < alen && tsp_rl_isspace((unsigned char)after[i])) i++;
 

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -793,3 +793,55 @@ FOO &foo;
       arguments: (function_call_expression
         function: (function
           (varname))))))
+
+================================================================================
+chained comparison after a bareword is relational, not a fileglob (hybrid)
+================================================================================
+CONST < 7 > $x;
+CONST < $a/$b > $c;
+CONST < $a > foo;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (relational_expression
+      left: (relational_expression
+        left: (bareword)
+        right: (number))
+      right: (scalar
+        (varname))))
+  (expression_statement
+    (relational_expression
+      left: (relational_expression
+        left: (bareword)
+        right: (binary_expression
+          left: (scalar
+            (varname))
+          right: (scalar
+            (varname))))
+      right: (scalar
+        (varname))))
+  (expression_statement
+    (relational_expression
+      left: (relational_expression
+        left: (bareword)
+        right: (scalar
+          (varname)))
+      right: (bareword))))
+
+================================================================================
+glob-shaped content with a trailing low-prec keyword stays a fileglob (hybrid)
+================================================================================
+print <$dir/*> or die;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (lowprec_logical_expression
+      left: (ambiguous_function_call_expression
+        function: (function)
+        arguments: (fileglob_expression
+          content: (string_content
+            (scalar
+              (varname)))))
+      right: (bareword))))


### PR DESCRIPTION
**The chosen heuristic.** A hybrid of the three candidates (#241 glob-shape, #242 operand-negative, #243 orphan-lookahead): A's content-shape test and C's orphan lookahead fail on *disjoint* inputs, so gating one behind the other beats any single approach.

## Decision (`src/tsp_intuit_readline.h`)
1. Infix word-operator in content (`and/or/lt/gt/...`) ⇒ relational.
2. **Glob-shape gate:** content that is neither glob-shaped (metachar `*?[]{}~`, path `/`, filename-dot `foo.c`) nor a pure filehandle name (`$fh`, `STDIN`) ⇒ relational operand. *Keeps `CONST < $a > foo` relational — which a pure orphan-lookahead got wrong.*
3. **Post-`>` orphan lookahead** (only for glob-shaped content): a trailing bare term with no connecting operator ⇒ `<` was the operator. *Keeps `CONST < $a/$b > $c` relational — which a pure content test got wrong.*

Also fixes the scanner to gather the `<...>` body from right after `<` (incl. the `$ident` prefix the readline probe consumes), so the content gate sees the whole body — without this, `<$sner >` reached the heuristic with content `" "`.

## Validation (vs Perl ground truth)
| input | Perl | hybrid |
|-------|------|--------|
| `CONST < 7 > $x` | relational | ✅ REL |
| `CONST < $a > foo` | relational | ✅ REL |
| `CONST < $a/$b > $c` | relational | ✅ REL |
| `<*.c>` / `<$dir/*.txt>` / `print < *.c >` | glob | ✅ GLOB |
| `<$sner >, <*.c>` | glob | ✅ GLOB |
| `print <$dir/*> or die` | glob | ✅ GLOB |
| `<STDIN>` / `<$fh>` / `CONST <FH>` | readline | ✅ RLINE |

- `tree-sitter test`: **238/238** (incl. new corpus regression tests).
- Corpus: **251 error files — byte-identical to every single-heuristic variant; 0 regressions** across the 7731 installed-module files.

Supersedes #241 and #242 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)