### PR TITLE
Parse the generic KEYWORD (EXPR) BLOCK control-flow shape (given/when, match/case)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -204,6 +204,9 @@ module.exports = grammar({
     [$.return_expression],
     [$.function, $.bareword],
     [$.function, $.function_call_expression],
+    // a statement-leading bareword may head a `KEYWORD (EXPR) BLOCK` control
+    // construct or an ordinary function call; GLR resolves on the trailing block
+    [$.compound_block_statement, $.function_call_expression, $.function],
     [$._variables, $.indirect_object],
     // a builtin filehandle after a list-op is ambiguous between the indirect
     // object slot (`print STDERR LIST`) and a plain term argument
@@ -244,7 +247,7 @@ module.exports = grammar({
       $.method_declaration_statement,
       $.phaser_statement,
       $.conditional_statement,
-      /* TODO: given/when/default */
+      $.compound_block_statement,
       $.loop_statement,
       $.cstyle_for_statement,
       $.for_statement,
@@ -377,6 +380,20 @@ module.exports = grammar({
         field('block', $.block),
         optional($._else)
       ),
+    // Graceful-degradation catch-all for the control-flow *shape*
+    // `KEYWORD (EXPR) BLOCK` introduced by CPAN/pluggable keywords we don't
+    // model precisely — `given (X) {…}`, `when (X) {…}`, `match (X) {…}`, and
+    // any future clone. We recognize the shape (not the name) so the keyword
+    // isn't reserved from userland, and emit a generic node for the next layer
+    // (perl-lsp, which sees the `use`) to refine. Low dynamic precedence so a
+    // real function call / known construct always wins when one applies.
+    compound_block_statement: $ => prec.dynamic(1, seq(
+      field('keyword', alias($._bareword, $.keyword)),
+      // consume the always-on NONASSOC the scanner injects after `KEYWORD (` —
+      // otherwise it commits this to a function call and starves this branch.
+      '(', $._NONASSOC, field('condition', $._expr), ')',
+      field('block', $.block),
+    )),
     _loop_body: $ => seq(field('block', $.block), optseq('continue', field('continue', $.block))),
     loop_statement: $ => seq($._loops, '(', field('condition', $._expr), ')', $._loop_body),
     cstyle_for_statement: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -147,6 +147,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "compound_block_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "loop_statement"
         },
         {
@@ -1241,6 +1245,56 @@
           ]
         }
       ]
+    },
+    "compound_block_statement": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "keyword",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_bareword"
+              },
+              "named": true,
+              "value": "keyword"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_NONASSOC"
+          },
+          {
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expr"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          },
+          {
+            "type": "FIELD",
+            "name": "block",
+            "content": {
+              "type": "SYMBOL",
+              "name": "block"
+            }
+          }
+        ]
+      }
     },
     "_loop_body": {
       "type": "SEQ",
@@ -10010,6 +10064,11 @@
     [
       "function",
       "function_call_expression"
+    ],
+    [
+      "compound_block_statement",
+      "function_call_expression",
+      "function"
     ],
     [
       "_variables",

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -706,3 +706,38 @@ class Example :isa(BaseClass) {
         (block
           (expression_statement
             (number)))))))
+
+================================================================================
+Generic KEYWORD (EXPR) BLOCK control construct (given/when, match/case, etc.)
+================================================================================
+given ($x) {
+  when (1) { foo() }
+}
+match ($y) { case (2) { bar() } }
+--------------------------------------------------------------------------------
+
+(source_file
+  (compound_block_statement
+    keyword: (keyword)
+    condition: (scalar
+      (varname))
+    block: (block
+      (compound_block_statement
+        keyword: (keyword)
+        condition: (number)
+        block: (block
+          (expression_statement
+            (function_call_expression
+              function: (function)))))))
+  (compound_block_statement
+    keyword: (keyword)
+    condition: (scalar
+      (varname))
+    block: (block
+      (compound_block_statement
+        keyword: (keyword)
+        condition: (number)
+        block: (block
+          (expression_statement
+            (function_call_expression
+              function: (function))))))))


### PR DESCRIPTION
**Draft / prototype** — graceful-degradation parsing for the shape-1 control-flow family.

## What
Adds `compound_block_statement`: a statement-leading bareword keyword + `(EXPR)` + block, recognized by **shape, not name**. Covers `given`/`when`, `match`/`case`, and any CPAN/pluggable clone without reserving the keyword from userland.

```
(compound_block_statement
  keyword: (keyword)        # given / when / match / anything
  condition: (...)          # the (EXPR)
  block: (block ...))       # inner when/case recurse through the same rule
```

## Why
The previous accidental call+block fallback was unreliable — a GLR error-recovery quirk made it error for exactly the short keywords that matter (`given`/`when`/`match` are all ≤5 chars). This makes the degradation *designed* and stable.

## Properties
- `match($x)` call, `sub match {}`, `if`/`while`/`for`, `try`/`catch`, `mygrep {…}` all **untouched**.
- Inner clauses recurse — no global keyword reservation (#187's concern).
- Consumes the post-`(` `_NONASSOC` marker so the function-call commitment doesn't starve the rule; needs a **single declared conflict**.
- perl-lsp (which sees the `use`) refines semantics.

## Numbers
- Corpus: **no regressions**, +1 file (a given/when test); suite **264/264**; **+10** large states.

## Known limitations (follow-ups)
- `match ($x : ==)` (Syntax::Keyword::Match dispatch op): statement form degrades cleanly — error is bounded to just the `: ==` token, block parses fully. Expression form (`my $r = match(X){…}`) cascades within the expression (bounded to the statement). Expression-position support is a separate, bigger lift.
- `default {…}` / no-paren clauses ride the existing ambiguous-call path (degrade to a hashref-arg call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)