### PR TITLE
Force parenless list-op gobbling statically (fixes `return bless {}, $class`, kills ~300 large states)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,28 +115,26 @@ Other scanner responsibilities:
   boundaries.
 - **Autoquote tokens** (`_fat_comma_autoquoted`, `_brace_autoquoted`): barewords
   that auto-stringify before `=>` or inside hash subscripts.
-- **List-op gobbling via `_gobbling_listexpr`:** a parenless list-op consumes
-  everything to its right (`return bless {}, $class` ≡ `return bless({}, $class)`),
-  but when GLR forks on the comma every reading has the *same node multiset* —
-  the trees differ only in where the `list_expression` lands, so default
-  tie-breaking picks arbitrarily (and wrongly). The fix is **position-specific
-  dynamic precedence**: `_gobbling_listexpr` is `_listexpr` re-wrapped so the
-  multi-term reading (and a parenless-call-as-lone-argument reading, which
-  breaks the `print join ',', @x` two-listop tie) carries `prec.dynamic`. It's
-  used *only* in list-op argument slots (ambiguous calls, no-paren sort/map);
-  `return` stays on neutral `_listexpr` so plain `return 1, 2` still beats the
-  statement-level list. Putting the dyn prec on the shared `_term_rightward`
-  itself wouldn't work — every competing reading reduces that same production
-  exactly once, so all forks would score identically.
-  Known boundary (adversarially probed): self-nested listop-with-comma chains
-  like `print join ",", print join ",", …` hold up to 3 levels; at ≥4 the GLR
-  version cap prunes the gobbling stack before it banks its rewards (gobbling
-  = delaying reduction, so its `prec.dynamic` only lands at the `;` while flat
-  readings bank +2 per chunk early) and the top levels degrade gracefully to
-  the old flat statement-list parse — no ERROR nodes. Not fixable in-grammar:
-  the version cap is a tree-sitter library constant. Plain chains are fine at
-  scale (200× `sner 1, 2, sner …` and 100-deep `sner sner … 1, 2` both parse
-  fully nested, no slowdown).
+- **List-op gobbling is forced statically, not GLR-arbitrated:** a parenless
+  list-op consumes everything to its right (`return bless {}, $class` ≡
+  `return bless({}, $class)`), i.e. at a comma the parser must *always*
+  continue the innermost open list. This is encoded as `prec.right` on the
+  `_term` production of `_listexpr`: in the equal-precedence shift/reduce
+  against `_term_rightward`'s comma, a right-associative reduce means "prefer
+  the shift", so the close-the-call-and-escape reading is never even forked.
+  Which consumer owns the finished flat list is then deterministic — it
+  reduces into whatever sits below it on the stack (the innermost list-taker).
+  Two dead ends, both tried: (1) a `[$._listexpr, $._term_rightward]` GLR
+  conflict + dynamic precedence can't arbitrate this — the competing readings
+  have *identical node multisets* (the `list_expression` just lands elsewhere),
+  per-position `prec.dynamic` rewards land only when the gobbling stack finally
+  reduces at `;`, and under self-nested chains (`print join ",", print join
+  ",", …` ≥4 deep) the version cap prunes the late-banking gobble stack before
+  payday. (2) raising `_term_rightward` to `prec.right(1)` makes *completing*
+  a list beat *continuing* its own repeat1, so lists close after their second
+  element (stacked-heredoc tests catch it). The static fix removed that GLR
+  conflict entirely: −300 large states, ~2× faster on comma-heavy input, zero
+  stack versions spent, correct at any nesting depth.
 - **State golfing via `alias()`:** the cheapest real state reductions come from
   factoring a repeated shape (subscript bodies `[..]`/`{..}`/`(..)`, the shared
   sub/method attribute+signature+body tail) into one hidden rule, then `alias()`-ing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,28 @@ Other scanner responsibilities:
   boundaries.
 - **Autoquote tokens** (`_fat_comma_autoquoted`, `_brace_autoquoted`): barewords
   that auto-stringify before `=>` or inside hash subscripts.
+- **List-op gobbling via `_gobbling_listexpr`:** a parenless list-op consumes
+  everything to its right (`return bless {}, $class` ≡ `return bless({}, $class)`),
+  but when GLR forks on the comma every reading has the *same node multiset* —
+  the trees differ only in where the `list_expression` lands, so default
+  tie-breaking picks arbitrarily (and wrongly). The fix is **position-specific
+  dynamic precedence**: `_gobbling_listexpr` is `_listexpr` re-wrapped so the
+  multi-term reading (and a parenless-call-as-lone-argument reading, which
+  breaks the `print join ',', @x` two-listop tie) carries `prec.dynamic`. It's
+  used *only* in list-op argument slots (ambiguous calls, no-paren sort/map);
+  `return` stays on neutral `_listexpr` so plain `return 1, 2` still beats the
+  statement-level list. Putting the dyn prec on the shared `_term_rightward`
+  itself wouldn't work — every competing reading reduces that same production
+  exactly once, so all forks would score identically.
+  Known boundary (adversarially probed): self-nested listop-with-comma chains
+  like `print join ",", print join ",", …` hold up to 3 levels; at ≥4 the GLR
+  version cap prunes the gobbling stack before it banks its rewards (gobbling
+  = delaying reduction, so its `prec.dynamic` only lands at the `;` while flat
+  readings bank +2 per chunk early) and the top levels degrade gracefully to
+  the old flat statement-list parse — no ERROR nodes. Not fixable in-grammar:
+  the version cap is a tree-sitter library constant. Plain chains are fine at
+  scale (200× `sner 1, 2, sner …` and 100-deep `sner sner … 1, 2` both parse
+  fully nested, no slowdown).
 - **State golfing via `alias()`:** the cheapest real state reductions come from
   factoring a repeated shape (subscript bodies `[..]`/`{..}`/`(..)`, the shared
   sub/method attribute+signature+body tail) into one hidden rule, then `alias()`-ing

--- a/grammar.js
+++ b/grammar.js
@@ -198,13 +198,6 @@ module.exports = grammar({
   ],
   conflicts: $ => [
     [$.preinc_expression, $.postinc_expression],
-    // we need this b/c otherwise a nested term will eat its children's nodes (print print 1, 2, 3)
-    [$._listexpr, $._term_rightward],
-    // same fork for the list-op argument flavor; dynamic prec then picks the gobbling stack
-    [$._gobbling_listexpr, $._term_rightward],
-    // a parenless call as a lone argument reduces both ways (rewarded arg vs plain term);
-    // the trees are identical and dynamic prec keeps the rewarded one
-    [$._gobbling_listexpr, $._listop],
     // all of the following go GLR b/c they need extra tokens to allow postfixy autoquotes
     [$.return_expression],
     [$.function, $.bareword],
@@ -451,35 +444,25 @@ module.exports = grammar({
       prec.left(TERMPREC.OROP, binop(choice('or', 'xor'), $._expr)),
     ),
 
+    /* A parenless list operator gobbles everything to its right
+     * (`return bless {}, $class` ≡ `return bless({}, $class)`), so at a comma
+     * the parser must ALWAYS continue the innermost open list, never close a
+     * call and let the comma escape to an enclosing return/list. We force that
+     * branch statically: the `_term` production here is prec.right, so the
+     * equal-precedence shift/reduce against `_term_rightward`'s comma resolves
+     * toward the shift (right-assoc reduce = prefer shift) and the escape
+     * readings are never even forked. Which consumer owns the finished flat
+     * list stays deterministic — it reduces to whatever's below it on the
+     * stack, which is exactly the innermost list-taker. */
     _listexpr: $ => choice(
       alias($._term_rightward, $.list_expression),
-      $._term
+      prec.right($._term)
     ),
     /* ensure that an entire list expression's contents appear in one big flat
     * list, while permitting multiple internal commas and an optional trailing one */
     _term_rightward: $ => prec.right(seq(
       $._term, repeat1(seq($._PERLY_COMMA, optional($._term))),
     )),
-    /* The no-paren argument list of a list operator. Shape-identical to
-     * _listexpr, but the multi-term reading carries dynamic precedence: when
-     * GLR forks on a comma ("does `, $x` continue this call's arguments, or
-     * escape to an enclosing return/list?") the innermost list-op must gobble
-     * it — perl's rule is that a parenless list-op consumes everything to its
-     * right, so `return bless {}, $class` is `return bless({}, $class)`.
-     * `return` itself stays on plain _listexpr (neutral): a list argument to
-     * a real list-op outscores it, while bare `return 1, 2` keeps winning
-     * against the statement-level list the same way it always has.
-     * The second production breaks the two-listop tie (`print join ',', @x`):
-     * both "print gobbles" and "join gobbles" contain exactly one rewarded
-     * list, but only the correct innermost-gobble reading ALSO has a parenless
-     * call as the outer call's entire argument, so reward that shape too. A
-     * paren'd call can't trip this — it reduces to function_call_expression,
-     * not the ambiguous node — so `print foo(1), $y` keeps print's list. */
-    _gobbling_listexpr: $ => choice(
-      prec.dynamic(2, alias($._term_rightward, $.list_expression)),
-      prec.dynamic(2, $.ambiguous_function_call_expression),
-      $._term
-    ),
 
     subscripted: $ => choice(
       $.glob_slot_expression,
@@ -869,8 +852,8 @@ module.exports = grammar({
 
     _map_grep: $ => choice('map', 'grep'),
     map_grep_expression: $ => prec.left(TERMPREC.LSTOP, choice(
-      seq($._map_grep, field('callback', $.block), field('list', $._gobbling_listexpr)),
-      seq($._map_grep, field('callback', $._term), $._PERLY_COMMA, field('list', $._gobbling_listexpr)),
+      seq($._map_grep, field('callback', $.block), field('list', $._listexpr)),
+      seq($._map_grep, field('callback', $._term), $._PERLY_COMMA, field('list', $._listexpr)),
       seq($._map_grep, '(', $._NONASSOC, field('callback', $._term), $._PERLY_COMMA, field('list', $._listexpr), ')'),
       seq($._map_grep, '(', $._NONASSOC, field('callback', $.block), field('list', $._listexpr), ')'),
     )),
@@ -882,7 +865,7 @@ module.exports = grammar({
     // hashref
     _sort_routine: $ => choice(prec(1, alias($._bareword, $.function)), $.block, prec(1, $.scalar)),
     sort_expression: $ => prec.left(TERMPREC.LSTOP, choice(
-      seq('sort', optional(field('callback', $._sort_routine)), field('list', $._gobbling_listexpr)),
+      seq('sort', optional(field('callback', $._sort_routine)), field('list', $._listexpr)),
       seq('sort', '(', $._NONASSOC, optional(field('callback', $._sort_routine)), field('list', $._listexpr), ')'),
     )),
 
@@ -956,15 +939,15 @@ module.exports = grammar({
           // through to a plain term in a binary_expression). This sacrifices
           // `myfunc /x/` (becomes division), but `myfunc(/x/)` is unaffected
           // (parens make it unambiguous).
-          seq(field('function', alias($._listop_keyword, $.function)), field('arguments', $._gobbling_listexpr)),
-          seq(field('function', alias($._indirob_listop, $.function)), field('arguments', $._gobbling_listexpr)),
-          seq(field('function', $.function), optional($._no_search_slash_plz), field('arguments', $._gobbling_listexpr)),
-          seq(field('function', $.function), $.indirect_object, field('arguments', $._gobbling_listexpr)),
-          seq(field('function', alias($._indirob_listop, $.function)), $.indirect_object, field('arguments', $._gobbling_listexpr)),
+          seq(field('function', alias($._listop_keyword, $.function)), field('arguments', $._listexpr)),
+          seq(field('function', alias($._indirob_listop, $.function)), field('arguments', $._listexpr)),
+          seq(field('function', $.function), optional($._no_search_slash_plz), field('arguments', $._listexpr)),
+          seq(field('function', $.function), $.indirect_object, field('arguments', $._listexpr)),
+          seq(field('function', alias($._indirob_listop, $.function)), $.indirect_object, field('arguments', $._listexpr)),
           // we handle this_takes_a_block { thing; other_thing }; here. we don't wanna accept an indirob of scalar tho
           seq(field('function', $.function), alias($.block, $.indirect_object)),
           // we handle cases like takes_a_hash { 1 => 2 }; by having this special case
-          seq(field('function', $.function), field('arguments', alias($._tricky_indirob_hashref, $.anonymous_hash_expression)), optseq($._PERLY_COMMA, field('arguments', $._gobbling_listexpr)))
+          seq(field('function', $.function), field('arguments', alias($._tricky_indirob_hashref, $.anonymous_hash_expression)), optseq($._PERLY_COMMA, field('arguments', $._listexpr)))
         )
       ),
     // Builtin LIST operators. This is the `@function.builtin` list-op set from

--- a/grammar.js
+++ b/grammar.js
@@ -200,6 +200,11 @@ module.exports = grammar({
     [$.preinc_expression, $.postinc_expression],
     // we need this b/c otherwise a nested term will eat its children's nodes (print print 1, 2, 3)
     [$._listexpr, $._term_rightward],
+    // same fork for the list-op argument flavor; dynamic prec then picks the gobbling stack
+    [$._gobbling_listexpr, $._term_rightward],
+    // a parenless call as a lone argument reduces both ways (rewarded arg vs plain term);
+    // the trees are identical and dynamic prec keeps the rewarded one
+    [$._gobbling_listexpr, $._listop],
     // all of the following go GLR b/c they need extra tokens to allow postfixy autoquotes
     [$.return_expression],
     [$.function, $.bareword],
@@ -455,6 +460,26 @@ module.exports = grammar({
     _term_rightward: $ => prec.right(seq(
       $._term, repeat1(seq($._PERLY_COMMA, optional($._term))),
     )),
+    /* The no-paren argument list of a list operator. Shape-identical to
+     * _listexpr, but the multi-term reading carries dynamic precedence: when
+     * GLR forks on a comma ("does `, $x` continue this call's arguments, or
+     * escape to an enclosing return/list?") the innermost list-op must gobble
+     * it — perl's rule is that a parenless list-op consumes everything to its
+     * right, so `return bless {}, $class` is `return bless({}, $class)`.
+     * `return` itself stays on plain _listexpr (neutral): a list argument to
+     * a real list-op outscores it, while bare `return 1, 2` keeps winning
+     * against the statement-level list the same way it always has.
+     * The second production breaks the two-listop tie (`print join ',', @x`):
+     * both "print gobbles" and "join gobbles" contain exactly one rewarded
+     * list, but only the correct innermost-gobble reading ALSO has a parenless
+     * call as the outer call's entire argument, so reward that shape too. A
+     * paren'd call can't trip this — it reduces to function_call_expression,
+     * not the ambiguous node — so `print foo(1), $y` keeps print's list. */
+    _gobbling_listexpr: $ => choice(
+      prec.dynamic(2, alias($._term_rightward, $.list_expression)),
+      prec.dynamic(2, $.ambiguous_function_call_expression),
+      $._term
+    ),
 
     subscripted: $ => choice(
       $.glob_slot_expression,
@@ -844,8 +869,8 @@ module.exports = grammar({
 
     _map_grep: $ => choice('map', 'grep'),
     map_grep_expression: $ => prec.left(TERMPREC.LSTOP, choice(
-      seq($._map_grep, field('callback', $.block), field('list', $._listexpr)),
-      seq($._map_grep, field('callback', $._term), $._PERLY_COMMA, field('list', $._listexpr)),
+      seq($._map_grep, field('callback', $.block), field('list', $._gobbling_listexpr)),
+      seq($._map_grep, field('callback', $._term), $._PERLY_COMMA, field('list', $._gobbling_listexpr)),
       seq($._map_grep, '(', $._NONASSOC, field('callback', $._term), $._PERLY_COMMA, field('list', $._listexpr), ')'),
       seq($._map_grep, '(', $._NONASSOC, field('callback', $.block), field('list', $._listexpr), ')'),
     )),
@@ -857,7 +882,7 @@ module.exports = grammar({
     // hashref
     _sort_routine: $ => choice(prec(1, alias($._bareword, $.function)), $.block, prec(1, $.scalar)),
     sort_expression: $ => prec.left(TERMPREC.LSTOP, choice(
-      seq('sort', optional(field('callback', $._sort_routine)), field('list', $._listexpr)),
+      seq('sort', optional(field('callback', $._sort_routine)), field('list', $._gobbling_listexpr)),
       seq('sort', '(', $._NONASSOC, optional(field('callback', $._sort_routine)), field('list', $._listexpr), ')'),
     )),
 
@@ -931,15 +956,15 @@ module.exports = grammar({
           // through to a plain term in a binary_expression). This sacrifices
           // `myfunc /x/` (becomes division), but `myfunc(/x/)` is unaffected
           // (parens make it unambiguous).
-          seq(field('function', alias($._listop_keyword, $.function)), field('arguments', $._listexpr)),
-          seq(field('function', alias($._indirob_listop, $.function)), field('arguments', $._listexpr)),
-          seq(field('function', $.function), optional($._no_search_slash_plz), field('arguments', $._listexpr)),
-          seq(field('function', $.function), $.indirect_object, field('arguments', $._listexpr)),
-          seq(field('function', alias($._indirob_listop, $.function)), $.indirect_object, field('arguments', $._listexpr)),
+          seq(field('function', alias($._listop_keyword, $.function)), field('arguments', $._gobbling_listexpr)),
+          seq(field('function', alias($._indirob_listop, $.function)), field('arguments', $._gobbling_listexpr)),
+          seq(field('function', $.function), optional($._no_search_slash_plz), field('arguments', $._gobbling_listexpr)),
+          seq(field('function', $.function), $.indirect_object, field('arguments', $._gobbling_listexpr)),
+          seq(field('function', alias($._indirob_listop, $.function)), $.indirect_object, field('arguments', $._gobbling_listexpr)),
           // we handle this_takes_a_block { thing; other_thing }; here. we don't wanna accept an indirob of scalar tho
           seq(field('function', $.function), alias($.block, $.indirect_object)),
           // we handle cases like takes_a_hash { 1 => 2 }; by having this special case
-          seq(field('function', $.function), field('arguments', alias($._tricky_indirob_hashref, $.anonymous_hash_expression)), optseq($._PERLY_COMMA, field('arguments', $._listexpr)))
+          seq(field('function', $.function), field('arguments', alias($._tricky_indirob_hashref, $.anonymous_hash_expression)), optseq($._PERLY_COMMA, field('arguments', $._gobbling_listexpr)))
         )
       ),
     // Builtin LIST operators. This is the `@function.builtin` list-op set from

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1941,8 +1941,12 @@
           "value": "list_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "_term"
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SYMBOL",
+            "name": "_term"
+          }
         }
       ]
     },
@@ -1982,36 +1986,6 @@
           }
         ]
       }
-    },
-    "_gobbling_listexpr": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC_DYNAMIC",
-          "value": 2,
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_term_rightward"
-            },
-            "named": true,
-            "value": "list_expression"
-          }
-        },
-        {
-          "type": "PREC_DYNAMIC",
-          "value": 2,
-          "content": {
-            "type": "SYMBOL",
-            "name": "ambiguous_function_call_expression"
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_term"
-        }
-      ]
     },
     "subscripted": {
       "type": "CHOICE",
@@ -5255,7 +5229,7 @@
                 "name": "list",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -5284,7 +5258,7 @@
                 "name": "list",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -5434,7 +5408,7 @@
                 "name": "list",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -5933,7 +5907,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -5959,7 +5933,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -5992,7 +5966,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -6017,7 +5991,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -6047,7 +6021,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_gobbling_listexpr"
+                  "name": "_listexpr"
                 }
               }
             ]
@@ -6113,7 +6087,7 @@
                         "name": "arguments",
                         "content": {
                           "type": "SYMBOL",
-                          "name": "_gobbling_listexpr"
+                          "name": "_listexpr"
                         }
                       }
                     ]
@@ -10025,18 +9999,6 @@
     [
       "preinc_expression",
       "postinc_expression"
-    ],
-    [
-      "_listexpr",
-      "_term_rightward"
-    ],
-    [
-      "_gobbling_listexpr",
-      "_term_rightward"
-    ],
-    [
-      "_gobbling_listexpr",
-      "_listop"
     ],
     [
       "return_expression"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1983,6 +1983,36 @@
         ]
       }
     },
+    "_gobbling_listexpr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_DYNAMIC",
+          "value": 2,
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_term_rightward"
+            },
+            "named": true,
+            "value": "list_expression"
+          }
+        },
+        {
+          "type": "PREC_DYNAMIC",
+          "value": 2,
+          "content": {
+            "type": "SYMBOL",
+            "name": "ambiguous_function_call_expression"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_term"
+        }
+      ]
+    },
     "subscripted": {
       "type": "CHOICE",
       "members": [
@@ -5225,7 +5255,7 @@
                 "name": "list",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -5254,7 +5284,7 @@
                 "name": "list",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -5404,7 +5434,7 @@
                 "name": "list",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -5903,7 +5933,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -5929,7 +5959,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -5962,7 +5992,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -5987,7 +6017,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -6017,7 +6047,7 @@
                 "name": "arguments",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_listexpr"
+                  "name": "_gobbling_listexpr"
                 }
               }
             ]
@@ -6083,7 +6113,7 @@
                         "name": "arguments",
                         "content": {
                           "type": "SYMBOL",
-                          "name": "_listexpr"
+                          "name": "_gobbling_listexpr"
                         }
                       }
                     ]
@@ -9999,6 +10029,14 @@
     [
       "_listexpr",
       "_term_rightward"
+    ],
+    [
+      "_gobbling_listexpr",
+      "_term_rightward"
+    ],
+    [
+      "_gobbling_listexpr",
+      "_listop"
     ],
     [
       "return_expression"

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -501,6 +501,54 @@ return map { $_ } @x, @y;
             (varname)))))))
 
 ================================================================================
+self-nested parenless list-ops gobble at any depth (adversarial)
+================================================================================
+print print 1, 2;
+print join ",", print join ",", print join ",", print join ",", @x;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (ambiguous_function_call_expression
+      (function)
+      (ambiguous_function_call_expression
+        (function)
+        (list_expression
+          (number)
+          (number)))))
+  (expression_statement
+    (ambiguous_function_call_expression
+      (function)
+      (ambiguous_function_call_expression
+        (function)
+        (list_expression
+          (interpolated_string_literal
+            (string_content))
+          (ambiguous_function_call_expression
+            (function)
+            (ambiguous_function_call_expression
+              (function)
+              (list_expression
+                (interpolated_string_literal
+                  (string_content))
+                (ambiguous_function_call_expression
+                  (function)
+                  (ambiguous_function_call_expression
+                    (function)
+                    (list_expression
+                      (interpolated_string_literal
+                        (string_content))
+                      (ambiguous_function_call_expression
+                        (function)
+                        (ambiguous_function_call_expression
+                          (function)
+                          (list_expression
+                            (interpolated_string_literal
+                              (string_content))
+                            (array
+                              (varname))))))))))))))))
+
+================================================================================
 parenthesized list-op call: `{…}` is a hashref arg, except the indirob set
 ================================================================================
 bless({%$arg}, $class);

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -212,9 +212,10 @@ print 'things', sum 1, 2, 3;
           (string_content))
         (ambiguous_function_call_expression
           (function)
-          (number))
-        (number)
-        (number)))))
+          (list_expression
+            (number)
+            (number)
+            (number)))))))
 
 ================================================================================
 ambiguous funcs with indirect objects
@@ -442,6 +443,62 @@ exec {$prog} @args;
               (varname)))))
       arguments: (array
         (varname)))))
+
+================================================================================
+a nested parenless list-op gobbles the comma list
+================================================================================
+return bless {}, $class;
+print join ',', @list;
+return sort { $a <=> $b } @x, @y;
+return map { $_ } @x, @y;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (return_expression
+      (ambiguous_function_call_expression
+        (function)
+        (list_expression
+          (anonymous_hash_expression)
+          (scalar
+            (varname))))))
+  (expression_statement
+    (ambiguous_function_call_expression
+      (function)
+      (ambiguous_function_call_expression
+        (function)
+        (list_expression
+          (string_literal
+            (string_content))
+          (array
+            (varname))))))
+  (expression_statement
+    (return_expression
+      (sort_expression
+        (block
+          (expression_statement
+            (equality_expression
+              (scalar
+                (varname))
+              (scalar
+                (varname)))))
+        (list_expression
+          (array
+            (varname))
+          (array
+            (varname))))))
+  (expression_statement
+    (return_expression
+      (map_grep_expression
+        (block
+          (expression_statement
+            (scalar
+              (varname))))
+        (list_expression
+          (array
+            (varname))
+          (array
+            (varname)))))))
 
 ================================================================================
 parenthesized list-op call: `{…}` is a hashref arg, except the indirob set


### PR DESCRIPTION
## The bug (field report)

`return bless {}, $class` parsed as `(return bless({})), $class` — the comma escaped the call. Same failure for every parenless list-op under another list context: `return join ',', @x`, `return sort { … } @x, @y`, `return map { … } @x, @y`, `print join ',', @x`, `print bless {}, $class`…

Perl's rule (confirmed against `perl -MO=Deparse`): a parenless list operator gobbles everything to its right, so the comma must always continue the **innermost** open list.

## Why GLR couldn't fix it

The `[$._listexpr, $._term_rightward]` conflict forked the parse at every comma, and the competing readings have *identical node multisets* — the `list_expression` just lands in a different parent — so resolution fell to tree-sitter's arbitrary structural tie-break, which picked the outermost attachment. The first commit fixes this with position-specific dynamic precedence (`_gobbling_listexpr`), which works for all the common idioms but has an inherent boundary: the gobbling stack only banks its `prec.dynamic` rewards when its lists finally reduce at `;`, so under self-nested chains (`print join ",", print join ",", …` ≥4 deep) the GLR version cap (21 live stacks) prunes it before payday.

## The actual fix

There's nothing for GLR to decide — gobbling is unconditional. The second commit forces the branch statically: `prec.right` on the `_term` production of `_listexpr` resolves the equal-precedence shift/reduce against `_term_rightward`'s comma toward the shift, so the escape readings are never forked at all. Which consumer owns the finished flat list stays deterministic — it reduces into whatever sits below it on the stack, i.e. the innermost list-taker. The `[$._listexpr, $._term_rightward]` conflict is deleted (its comment shows it existed to keep `print print 1, 2, 3` flat — which was the wrong parse all along), and the dyn-prec machinery from the first commit is retired.

## Results

- **LARGE_STATE_COUNT 3693 → 3375** (−318, −8.6%); STATE_COUNT 5645 → 5317
- Comma lexing never forks (`parse -d` shows `version_count:1` throughout); ~2.5× faster on comma-heavy input
- Correct at any nesting depth: 200-element `sner 1, 2, sner …` chains and 4-deep self-nested `print join` towers all parse fully nested, zero ERROR nodes
- 265/265 corpus tests; one pre-existing expectation updated (`print 'things', sum 1, 2, 3` had the buggy flat parse baked in — deparse says `sum` gobbles)
- New corpus blocks pin the fixed idioms plus the adversarial self-nested shapes that discriminate the static approach from the GLR one

One instructive dead end documented in CLAUDE.md: raising `_term_rightward` itself to `prec.right(1)` makes *completing* a list beat *continuing its own repeat1*, so every list closes after its second element (the stacked-heredoc tests catch it instantly). The right lever is associativity on the `→ _term` reduce, not precedence on the list rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)