### PR TITLE
fix(scanner): autoquote fat-comma keys when the error-recovery gate is active

### DIFF
--- a/generate_keywords.pl
+++ b/generate_keywords.pl
@@ -46,16 +46,19 @@ path('./src/tsp_keywords.h')->spew(<<C);
 #define KEYWORD_WORD_CHAR(la) \\
   ($word_char_test)
 
-// Keyword matching: sets needs_name for keywords that require an
-// identifier to be a declaration (sub, method).  Falls through to
-// PEEK_NOT_KEYWORD for non-keywords.
-#define KEYWORD_MATCH(word, needs_name) do { \\
+// Keyword classification: sets `kind` to one of the KwKind values.
+//   KW_NONE       — not a statement keyword (a plain bareword / autoquote key)
+//   KW_ALWAYS     — always a statement keyword (package, use, no, class, role)
+//   KW_NEEDS_NAME — only a declaration if followed by a name (sub, method)
+// Unlike a bare match this never returns: the caller decides what to do with a
+// non-keyword, which may still be a fat-comma autoquote key.
+#define KEYWORD_MATCH(word, kind) do { \\
     if ($always_test) { \\
-      /* always statement keywords */ \\
+      (kind) = KW_ALWAYS; \\
     } else if ($named_test) { \\
-      (needs_name) = true; \\
+      (kind) = KW_NEEDS_NAME; \\
     } else { \\
-      return PEEK_NOT_KEYWORD; \\
+      (kind) = KW_NONE; \\
     } \\
   } while(0)
 C

--- a/grammar.js
+++ b/grammar.js
@@ -171,6 +171,7 @@ module.exports = grammar({
     $._heredoc_middle,
     $.heredoc_end,
     $._fat_comma_autoquoted,
+    $._fat_comma_autoquoted_ahead,
     $._filetest,
     $._brace_autoquoted_token,
     /* zero-width lookahead tokens */
@@ -1483,7 +1484,7 @@ module.exports = grammar({
         // minus autoquoting
         prec(TERMPREC.PAREN, seq('-', $._bareword)),
       ),
-      seq(optional('-'), $._fat_comma_autoquoted)
+      seq(optional($._fat_comma_autoquoted_ahead), optional('-'), $._fat_comma_autoquoted)
     ),
     // NOTE - these have zw lookaheads so they override just being read as barewords
     _brace_autoquoted: $ => alias($._brace_autoquoted_token, $.autoquoted_bareword),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9513,6 +9513,18 @@
               "type": "CHOICE",
               "members": [
                 {
+                  "type": "SYMBOL",
+                  "name": "_fat_comma_autoquoted_ahead"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "STRING",
                   "value": "-"
                 },
@@ -10174,6 +10186,10 @@
     {
       "type": "SYMBOL",
       "name": "_fat_comma_autoquoted"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_fat_comma_autoquoted_ahead"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -66,6 +66,7 @@ enum TokenType {
   TOKEN_HEREDOC_MIDDLE,
   TOKEN_HEREDOC_END,
   TOKEN_FAT_COMMA_AUTOQUOTED,
+  TOKEN_FAT_COMMA_AUTOQUOTED_AHEAD,
   TOKEN_FILETEST,
   TOKEN_BRACE_AUTOQUOTED,
   /* zero-width lookahead tokens */
@@ -372,10 +373,19 @@ static bool isidfirst(int32_t c);
 static bool isidcont(int32_t c);
 
 enum PeekResult {
-  PEEK_NO_MATCH,    // first char not a keyword starter — lexer untouched
-  PEEK_KEYWORD,     // statement keyword (not followed by =>)
-  PEEK_FAT_COMMA,   // keyword followed by => — caller should goto fat_comma_check
-  PEEK_NOT_KEYWORD, // word read but not a keyword — caller MUST return false
+  PEEK_NO_MATCH,      // first char not a keyword starter — lexer untouched
+  PEEK_KEYWORD,       // statement keyword (not followed by =>)
+  PEEK_FAT_COMMA,     // keyword followed by => — caller MARK_ENDs then goto fat_comma_check
+  PEEK_AUTOQUOTE_KEY, // non-keyword word followed by => — peek already marked the
+                      // word boundary; caller goes straight to fat_comma_check
+  PEEK_NOT_KEYWORD,   // word read but not a keyword — caller MUST return false
+};
+
+// How a word read by the keyword peek classifies (set by KEYWORD_MATCH).
+enum KwKind {
+  KW_NONE,       // not a statement keyword
+  KW_ALWAYS,     // always a statement keyword (package/use/no/class/role)
+  KW_NEEDS_NAME, // declaration only if followed by a name (sub/method)
 };
 
 static enum PeekResult peek_is_statement_keyword(TSLexer *lexer) {
@@ -394,31 +404,58 @@ static enum PeekResult peek_is_statement_keyword(TSLexer *lexer) {
   }
   word[len] = '\0';
 
-  // Must be a word boundary (not followed by more identifier chars)
-  if (isidcont(la))
+  // Classify *before* consuming any identifier tail: a statement keyword must
+  // end exactly at the keyword charset boundary.  A longer identifier (e.g.
+  // "service", "naming") read only partway by the loop above is never a
+  // keyword — but it can still be a fat-comma autoquote key, so we don't bail.
+  enum KwKind kind = KW_NONE;
+  if (!isidcont(la))
+    KEYWORD_MATCH(word, kind);
+
+  if (kind == KW_NONE) {
+    // Not a statement keyword.  It may still be a fat-comma autoquote key
+    // (`name => 1` on a continuation line inside an open list, where the
+    // recovery gate fires and would otherwise lex it as a plain bareword).
+    // Consume the rest of the identifier, mark the token end at the word
+    // boundary, then look past whitespace for '='.  The whole word must be
+    // covered, so skip with advance(false): advance(true) would reset the
+    // token start past the word and emit a zero-width key.  mark_end fixes the
+    // end at the word, so trailing whitespace stays out of the token anyway.
+    while (isidcont(la)) {
+      lexer->advance(lexer, false);
+      la = lexer->lookahead;
+    }
+    lexer->mark_end(lexer);
+    while (is_tsp_whitespace(la)) {
+      lexer->advance(lexer, false);
+      la = lexer->lookahead;
+    }
+    if (la == '=') return PEEK_AUTOQUOTE_KEY;
     return PEEK_NOT_KEYWORD;
+  }
 
-  bool needs_name = false;
-  KEYWORD_MATCH(word, needs_name);
-
-  // Skip whitespace after keyword (including newlines — the peek resets
-  // on failure, and we need to see past newlines for fat comma detection).
-  // Use advance(true) so whitespace is NOT included in the token.
+  // A statement keyword.  The caller already marked a zero-width position at
+  // the keyword start for recovery-token emission; leave that mark alone (don't
+  // mark_end here) and skip trailing whitespace with advance(true) — the
+  // original recovery-safe behavior.  A word-end mark here would make the
+  // recovery token swallow the keyword (and breaks the keyword-boundary tests).
   while (is_tsp_whitespace(la)) {
     lexer->advance(lexer, true);
     la = lexer->lookahead;
   }
 
-  // Fat comma => means it's a hash key, not a statement.
-  // Bail at '=' without advancing past it.  Caller will MARK_END
-  // (covering the word) then goto fat_comma_check.
+  // Fat comma => means even a keyword is a hash key, not a statement
+  // (`package => 1`).  The caller MARK_ENDs and resumes at fat_comma_check.
+  // NOTE: a keyword key inside an open list on a continuation line autoquotes
+  // but with a zero-width span (recovery's word-start mark wins over the
+  // word-end span an autoquote wants — see the split above).  Plain words and
+  // non-keyword builtins (sort/map/ref/state/…) take the KW_NONE path and get
+  // a correct span; only the 7 reserved statement keywords hit this edge.
   if (la == '=') return PEEK_FAT_COMMA;
 
   // For sub/method: only a declaration if followed by an identifier (name)
-  if (needs_name) {
-    if (!isidfirst(la))
-      return PEEK_NOT_KEYWORD;  // anonymous sub/method
-  }
+  if (kind == KW_NEEDS_NAME && !isidfirst(la))
+    return PEEK_NOT_KEYWORD;  // anonymous sub/method
 
   return PEEK_KEYWORD;
 }
@@ -766,12 +803,27 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
       if (valid_symbols[PERLY_SEMICOLON]) TOKEN(PERLY_SEMICOLON);
     }
     if (peek == PEEK_FAT_COMMA) {
-      // Fat comma — keyword followed by '='.  Bail to the autoquote
-      // handler's => check.  Peek left us at '=' with the word
-      // consumed and whitespace skipped (as true skip).  MARK_END
-      // covers just the word.  Same goto pattern as heredoc vs
-      // diamond disambiguation.
+      // A statement keyword used as a fat-comma key (`package => 1`).  We can't
+      // mark the word boundary here (peek preserved the caller's zero-width
+      // recovery mark for the keyword path, and re-marking would consume the
+      // keyword).  Instead emit a zero-width "autoquote ahead" marker at the
+      // word start: tree-sitter re-lexes the word via the normal autoquote
+      // path, which marks the word boundary correctly.  The recovery gate
+      // won't re-fire on re-entry (no newline precedes the word that scan), so
+      // there's no loop.  Falls back to the old (zero-width-span) emission if
+      // the marker isn't accepted in this state.
+      if (valid_symbols[TOKEN_FAT_COMMA_AUTOQUOTED_AHEAD])
+        TOKEN(TOKEN_FAT_COMMA_AUTOQUOTED_AHEAD);
       MARK_END;
+      c = lexer->lookahead;
+      goto fat_comma_check;
+    }
+    if (peek == PEEK_AUTOQUOTE_KEY) {
+      // A non-keyword bareword used as a fat-comma key (`name => 1`) on a
+      // continuation line where the recovery gate fired.  Peek already marked
+      // the token end at the word boundary (covering exactly the word), so do
+      // NOT MARK_END again — that would re-mark at '=' and emit a zero-width
+      // key.  Resume at the autoquote handler's => check.
       c = lexer->lookahead;
       goto fat_comma_check;
     }

--- a/src/tsp_keywords.h
+++ b/src/tsp_keywords.h
@@ -16,15 +16,18 @@
 #define KEYWORD_WORD_CHAR(la) \
   (la == 'a' || la == 'b' || la == 'c' || la == 'd' || la == 'e' || la == 'g' || la == 'h' || la == 'k' || la == 'l' || la == 'm' || la == 'n' || la == 'o' || la == 'p' || la == 'r' || la == 's' || la == 't' || la == 'u')
 
-// Keyword matching: sets needs_name for keywords that require an
-// identifier to be a declaration (sub, method).  Falls through to
-// PEEK_NOT_KEYWORD for non-keywords.
-#define KEYWORD_MATCH(word, needs_name) do { \
+// Keyword classification: sets `kind` to one of the KwKind values.
+//   KW_NONE       — not a statement keyword (a plain bareword / autoquote key)
+//   KW_ALWAYS     — always a statement keyword (package, use, no, class, role)
+//   KW_NEEDS_NAME — only a declaration if followed by a name (sub, method)
+// Unlike a bare match this never returns: the caller decides what to do with a
+// non-keyword, which may still be a fat-comma autoquote key.
+#define KEYWORD_MATCH(word, kind) do { \
     if (strcmp(word, "package") == 0 || strcmp(word, "use") == 0 || strcmp(word, "no") == 0 || strcmp(word, "class") == 0 || strcmp(word, "role") == 0) { \
-      /* always statement keywords */ \
+      (kind) = KW_ALWAYS; \
     } else if (strcmp(word, "sub") == 0 || strcmp(word, "method") == 0) { \
-      (needs_name) = true; \
+      (kind) = KW_NEEDS_NAME; \
     } else { \
-      return PEEK_NOT_KEYWORD; \
+      (kind) = KW_NONE; \
     } \
   } while(0)

--- a/test/corpus/error_recovery
+++ b/test/corpus/error_recovery
@@ -116,6 +116,38 @@ package => 1);
         (number)))))
 
 ================================================================================
+Fat-comma keys on continuation lines inside an open call autoquote
+================================================================================
+__PACKAGE__->add_columns(
+  first => 1,
+  name  => 2,
+  status => 3,
+  sort  => 4,
+  class => 5,
+  package => 6,
+);
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (method_call_expression
+      invocant: (func0op_call_expression)
+      method: (method)
+      arguments: (list_expression
+        (autoquoted_bareword)
+        (number)
+        (autoquoted_bareword)
+        (number)
+        (autoquoted_bareword)
+        (number)
+        (autoquoted_bareword)
+        (number)
+        (autoquoted_bareword)
+        (number)
+        (autoquoted_bareword)
+        (number)))))
+
+================================================================================
 Keyword boundary - postfix unless NOT broken
 ================================================================================
 print "hello"


### PR DESCRIPTION
## Problem

A bareword key in `KEY => VALUE` lexes as `autoquoted_bareword` everywhere **except** on a continuation line where the error-recovery gate is active — there it falls back to a plain `bareword` (clean parse, no ERROR):

```perl
__PACKAGE__->add_columns(
    first => 1,
    name  => 1,   # → (bareword), expected (autoquoted_bareword)
);
```

Reported downstream by perl-tree-sitter-lsp, which is currently working around it by treating any DSL key bareword as literal (a KLUDGE to be removed once fixed here).

## Root cause

The recovery gate (`crossed_newline && any_recovery_valid`) fires for any word starting with a keyword first-char (`c m n p r s u`) once recovery closers are valid (inside an open call/list/body). `peek_is_statement_keyword` consumed the word, found it wasn't a statement keyword, returned `PEEK_NOT_KEYWORD`, and the caller bailed with `return false` — so the external autoquote token was never produced and the word degraded to `bareword`. Top-level lists are unaffected (no recovery symbol valid there, so the gate never fires).

## Fix

- `KEYWORD_MATCH` now **classifies** into `KwKind` (`KW_NONE`/`KW_ALWAYS`/`KW_NEEDS_NAME`) instead of early-returning.
- Non-keyword words mark the word boundary and return the new `PEEK_AUTOQUOTE_KEY` → correct span, single pass.
- Statement keywords used as keys (`class => 1`) emit a zero-width `_fat_comma_autoquoted_ahead` marker, so tree-sitter re-lexes the word through the normal autoquote path with a correct span. The gate does not re-fire on re-entry (no newline precedes the word), so there's no loop and **no serialize/deserialize change**.

Cost: **+16 large states** (3375 → 3391).

## Scope note for reviewers

On **master** this bug only triggers in narrow nested contexts (inside a sub/method body), so it's largely latent — see validation. The user-visible top-level manifestation in the report comes from `feat/block-brace-recovery` (v1.1.3), which adds `RECOVER_BLOCK_CLOSE` to `any_recovery_valid` and so fires the gate at top level. This fix targets the root cause and is verified to resolve the top-level case once combined with that branch (feat + this fix: top-level repro autoquotes, 274/274 tests pass).

## Validation

- Full corpus differential over **92,247 files**, this branch vs master: **zero new parse errors** (identical 1157-file error set).
- Tree-level differential over **~23k real CPAN modules**: **zero behavioral changes** on master (confirming no regressions; the master trigger is too narrow to hit real code).
- `tree-sitter test`: all pass, incl. a new regression test covering non-keyword keys (`name`/`status`/`sort`) and reserved-keyword keys (`class`/`package`) on continuation lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)