### PR TITLE
Track known grammar coverage gaps

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -43,6 +43,8 @@ timeout — the failure count should not move.
 
 ## Latest results
 
+Known remaining grammar gaps are tracked in [`coverage-gaps.md`](coverage-gaps.md).
+
 Measured with `tree-sitter` 0.26.x against `ganezdragon/tree-sitter-perl`.
 
 **Broad corpus** — 8,334 files, perl5 core + major CPAN distributions

--- a/benchmark/coverage-gaps.md
+++ b/benchmark/coverage-gaps.md
@@ -48,8 +48,9 @@ apostrophes, …). Low ROI individually.
 
 - ~6 **intentional syntax-error test fixtures** (e.g. `DBICTest/SyntaxErrorComponent*.pm`,
   Mojo loader-exception fixtures). These *should* fail to parse.
-- A few **very large files that time out** under the benchmark's per-file limit —
-  not parse errors.
+(No timeouts: the entire corpus parses within the benchmark's per-file limit.
+The slowest parse is ~2.2s on a 9.8 MB file (`unicore/TestProp.pl`); everything
+else is well under 500ms. The grammar has no pathological slow-parse cases.)
 
 ## Recently addressed
 

--- a/benchmark/coverage-gaps.md
+++ b/benchmark/coverage-gaps.md
@@ -1,0 +1,59 @@
+# Known coverage gaps
+
+Constructs the grammar does not yet handle, surfaced by running it over the
+real-world corpus (see `README.md`). A living checklist — tick items as they
+land, and re-run the triage to refresh counts.
+
+Counts are approximate, from the triage of the broad corpus. They drift as
+fixes land; to refresh, re-run `benchmark/run.sh`, then re-triage the
+`last-ours.fail` set (extract each file's first ERROR/MISSING node + construct,
+cluster by root cause).
+
+Current standing: broad **126 / 8,334** fail (98.5%), gold **4 / 3,386** (99.9%).
+
+## Open clusters (grammar additions)
+
+- [ ] **`:prototype()` + sub-prototype sigils** (~11) — `sub f :prototype($$){}`,
+      `sub rad2deg ($;$)`. Prototype sigils (`$ ; \ & * +`) are parsed as a
+      signature; need a real prototype form + the `:prototype(...)` attribute.
+- [ ] **Test2 bareword-block builders** (~6) — `hash { … }`, `array { }`,
+      `field x => hash {…}`, bare `etc`. Generic bareword-takes-block-then-list.
+- [ ] **`x`-repeat glued to its count** (~4) — `$notcomp x10`, `${$x x2}`. There's
+      already an `_x_op` scanner token; extend it.
+- [ ] **v-strings with `_`** (~4) — `v1.2.3_0`, `v1.2_3`. Allow underscores
+      between version parts (plain `v1.2.3` already works).
+- [ ] **`continue { }` block** (~4) — `…} continue {…}` after a loop/bare block.
+      Today only the MISSING-`;` recovery fires; make it a real node.
+- [ ] **hex float literals** (~3) — `0x1p60`, `0x0.b17217f7d1cf78p0`.
+- [ ] **comma-before-`=>` in anon-hash** (~3) — `{ '-and', => [...] }`. Overlaps
+      the fat-comma autoquote work.
+- [ ] **apostrophe package separator** (~3) — `$main'a`, `sub CORE'print'foo`
+      (old `'` as `::`).
+- [ ] **given/when/default** (~2) — `given(){ when(){} }`. Shape-1 recovery only.
+
+## Gold-corpus singletons (the stubborn 4)
+
+- [ ] **C** — `s/ … /x` multiline substitution (Date::Format::Generic).
+- [ ] **E** — `return true() if /\Gtrue/gc` — `\G` match after a bareword (Mojo::JSON).
+- [ ] **F** — `->()` deref-call deep in a nested ternary (DateTime).
+- [ ] **H** — YAML::Tiny: an early construct errors the whole file ([0,0] wrapper).
+
+## Long tail
+
+~62 exotic one-file constructs (`$#[0]`, `@{-}` in regex, `0x_1234`, `&.`/`|.`
+string-bitwise ops, `0o100` new octal, `CORE::my`, `my($x => $y)`, glob with
+apostrophes, …). Low ROI individually.
+
+## Not grammar bugs (excluded from the above)
+
+- ~6 **intentional syntax-error test fixtures** (e.g. `DBICTest/SyntaxErrorComponent*.pm`,
+  Mojo loader-exception fixtures). These *should* fail to parse.
+- A few **very large files that time out** under the benchmark's per-file limit —
+  not parse errors.
+
+## Recently addressed
+
+class/role/method barewords · prefix `++`/`--` in parenless list-ops · phaser
+labels · `our`/`state sub` · unicode package identifiers · `format … .` ·
+`async { }` + `try(...)` · typed lexicals (`my Dog $spot`) · bare `eval`
+(which is what the mis-clustered "`map {…} <READLINE>`" failures actually were).

--- a/benchmark/coverage-gaps.md
+++ b/benchmark/coverage-gaps.md
@@ -2,59 +2,98 @@
 
 Constructs the grammar does not yet handle, surfaced by running it over the
 real-world corpus (see `README.md`). A living checklist — tick items as they
-land, and re-run the triage to refresh counts.
+land, and re-triage to refresh.
 
-Counts are approximate, from the triage of the broad corpus. They drift as
-fixes land; to refresh, re-run `benchmark/run.sh`, then re-triage the
-`last-ours.fail` set (extract each file's first ERROR/MISSING node + construct,
-cluster by root cause).
+To refresh: re-run `benchmark/run.sh`, then re-triage the `last-ours.fail` set —
+parse each, **walk to the innermost** ERROR/MISSING node (skip the whole-file
+`(source_file (ERROR …))` wrapper), read the line there, and cluster.
 
-Current standing: broad **126 / 8,334** fail (98.5%), gold **4 / 3,386** (99.9%).
+## Current standing (broad corpus, 8,334 files)
 
-## Open clusters (grammar additions)
+- **126 fail** (98.5% clean). Of those: **112 genuine grammar gaps**,
+  **9 intentional syntax-error fixtures** (not bugs), **5 non-UTF-8/binary**
+  files (not bugs). ~33 of the gaps are size-1 long-tail.
+- Gold corpus: **4 / 3,386 fail** (99.9%).
+- **No timeouts / slow parses** — the whole corpus parses within the limit;
+  slowest is ~2.2s on a 9.8 MB file, everything else <500ms.
 
-- [ ] **`:prototype()` + sub-prototype sigils** (~11) — `sub f :prototype($$){}`,
-      `sub rad2deg ($;$)`. Prototype sigils (`$ ; \ & * +`) are parsed as a
-      signature; need a real prototype form + the `:prototype(...)` attribute.
-- [ ] **Test2 bareword-block builders** (~6) — `hash { … }`, `array { }`,
-      `field x => hash {…}`, bare `etc`. Generic bareword-takes-block-then-list.
-- [ ] **`x`-repeat glued to its count** (~4) — `$notcomp x10`, `${$x x2}`. There's
-      already an `_x_op` scanner token; extend it.
-- [ ] **v-strings with `_`** (~4) — `v1.2.3_0`, `v1.2_3`. Allow underscores
-      between version parts (plain `v1.2.3` already works).
-- [ ] **`continue { }` block** (~4) — `…} continue {…}` after a loop/bare block.
-      Today only the MISSING-`;` recovery fires; make it a real node.
-- [ ] **hex float literals** (~3) — `0x1p60`, `0x0.b17217f7d1cf78p0`.
-- [ ] **comma-before-`=>` in anon-hash** (~3) — `{ '-and', => [...] }`. Overlaps
-      the fat-comma autoquote work.
-- [ ] **apostrophe package separator** (~3) — `$main'a`, `sub CORE'print'foo`
-      (old `'` as `::`).
-- [ ] **given/when/default** (~2) — `given(){ when(){} }`. Shape-1 recovery only.
+## Open clusters (genuine gaps, ranked by file count)
+
+- [ ] **sub prototype / signature sigils** (8) — `sub rad2deg ($;$){}`,
+      `sub($$) :Attr{}`, empty-proto-with-attr `sub () :const{}`,
+      `sub t($a,,, $b)`. Prototype sigils (`$ ; \ & * +`) are parsed as a
+      signature.
+- [ ] **Test2::V0 bareword-block builders** (7) — `field error => "…"`,
+      `hash {…}`, `bag { item $_; etc }`. Generic bareword-takes-block-then-list.
+- [ ] **regex / char-class quote+meta scanner mis-lex** (7) — a `/.../`  or
+      `qr{…}` whose char class mixes quote chars (`'"\``) with escaped brackets
+      (`\[\]`) or `{}` makes the scanner mis-pair a delimiter and swallow the
+      rest of the file. **Cascade**: the innermost ERROR lands far downstream
+      on an innocent line. Highest-value cluster (whole-file recovery).
+- [ ] **statement label before a block close** (6) — `L2:` (or `END:`, `done:`)
+      as the last thing before `}`, i.e. a label with no following statement.
+- [ ] **bareword constant before `*` or `/`** (5) — `PI * $_[0]`,
+      `DIV_SIZE * (@$cols-1)`. A constant bareword before `*`/`/` is read as a
+      glob/regex (`+`/`-` after a bareword are fine).
+- [ ] **`:prototype()` attribute** (4) — `sub getgrent :prototype( ) {}`.
+- [ ] **v-string with `_`** (4) — `v1.2_3`, `\v65.66.6_7`.
+- [ ] **comma before `=>` in anon-hash** (3) — `{ '-and', => [...] }`.
+- [ ] **`@-`/`@+`/`@{…}` punctuation-array interpolation** (3) — `"foo@{-}"`,
+      `qr/A@{-}B/`.
+- [ ] **hex float** (3) — `0x1p60`, `0x0.b17217f7d1cf78p0`.
+- [ ] **`continue { }` block** (3) — `} continue {…}`.
+- [ ] **apostrophe package separator** (3) — `$main'blurfl`, `$magic'H`.
+- [ ] **`<<` left-shift glued, mis-lexed as heredoc** (2) — `1<<index($x,$_)`,
+      `1<<$x` (no space); `1 << index` (spaced) is fine. Scanner heuristic.
+- [ ] **POD directive inside `q{}`/`qq{}`** (2) — a `=head1` at line-start
+      inside a quote enters POD mode and eats the rest of the file. **Cascade.**
+- [ ] **`x`-repeat glued to a number** (2) — `$notcomp x10`, `${$x x2}` (no
+      space). There's already an `_x_op` scanner token to extend.
+- [ ] **custom LHS bareword-block builder** (2) — `with_vars x {…}`,
+      `multicall_return {…} $g`.
+- [ ] **given/when** (2) — `given($x){ when(…){} }` (shape-1 recovery only).
+- [ ] **unicode in sub / variable names** (2) — `my sub φου`, `$ㄅĽuṞfⳐ`. (Package
+      names were fixed; sub/var-name paths still ASCII-only in places.)
+- [ ] **quote with embedded code mis-lex** (2, cascade) — `qq/ … $call(@args) … /`,
+      `q~ …code… ~` where the body trips the scanner.
+- [ ] **eval-STRING / indirect call in a ternary** (2, cascade) —
+      `is( eval 'Foo->boogie();1' ? … )`.
 
 ## Gold-corpus singletons (the stubborn 4)
 
 - [ ] **C** — `s/ … /x` multiline substitution (Date::Format::Generic).
-- [ ] **E** — `return true() if /\Gtrue/gc` — `\G` match after a bareword (Mojo::JSON).
+- [ ] **E** — `return true() if /\Gtrue/gc` — `\G` anchor after a bareword (Mojo::JSON).
 - [ ] **F** — `->()` deref-call deep in a nested ternary (DateTime).
-- [ ] **H** — YAML::Tiny: an early construct errors the whole file ([0,0] wrapper).
+- [ ] **H** — YAML::Tiny: a char-class regex mis-lex cascades the whole file.
 
-## Long tail
+## Long tail (~33 size-1 gaps)
 
-~62 exotic one-file constructs (`$#[0]`, `@{-}` in regex, `0x_1234`, `&.`/`|.`
-string-bitwise ops, `0o100` new octal, `CORE::my`, `my($x => $y)`, glob with
-apostrophes, …). Low ROI individually.
+`0o101` new octal · `0x_1234` underscore-after-radix · `s/…\K…/eggnog` (`\K` +
+nonstandard modifier) · `tr` with `\` delimiter · string-bitwise `&.`/`|.` ·
+`delete local @Pkg::{<a b>}` · `for CORE::my $v` · `CORE::__DATA__` ·
+`require;` (no arg) · `$^]` caret var · optional-chaining `?->` + try/catch ·
+`try … catch X with {}` (Error.pm) · fat-comma in `my(...)` · fileglob `<a'b'>` ·
+`-f ++ $x` · `"$_->@*"` postfix-deref in string · `new Oscalar …` indirect object ·
+`"$x[0]-> [0]"` arrow-space in string · `<<END` as a term · etc. Low ROI each.
 
-## Not grammar bugs (excluded from the above)
+## Not grammar bugs
 
-- ~6 **intentional syntax-error test fixtures** (e.g. `DBICTest/SyntaxErrorComponent*.pm`,
-  Mojo loader-exception fixtures). These *should* fail to parse.
-(No timeouts: the entire corpus parses within the benchmark's per-file limit.
-The slowest parse is ~2.2s on a 9.8 MB file (`unicore/TestProp.pl`); everything
-else is well under 500ms. The grammar has no pathological slow-parse cases.)
+- **9 intentional syntax-error test fixtures** (e.g. `DBICTest/SyntaxErrorComponent*.pm`,
+  Mojo loader-exception stubs, EOF-error tests). These *should* fail to parse.
+- **5 non-UTF-8 / binary** inputs (UTF-16BE BOM, ISO-8859, raw blobs, fuzz data).
+- (No timeouts: the whole corpus parses within the per-file limit; slowest is
+  ~2.2s on a 9.8 MB file.)
 
 ## Recently addressed
 
 class/role/method barewords · prefix `++`/`--` in parenless list-ops · phaser
-labels · `our`/`state sub` · unicode package identifiers · `format … .` ·
-`async { }` + `try(...)` · typed lexicals (`my Dog $spot`) · bare `eval`
-(which is what the mis-clustered "`map {…} <READLINE>`" failures actually were).
+labels · `our`/`state sub` · unicode **package** identifiers · `format … .` ·
+`async { }` + `try(...)` · typed lexicals (`my Dog $spot`) · bare `eval`.
+
+## High-value note for the next pass
+
+The biggest leverage is the **scanner-cascade** clusters — a single mis-lex
+(char-class regex, glued `<<`, POD-in-quote, embedded-code quote) errors the
+*entire file*, so each fix recovers a whole tree, not one line. The
+char-class/regex mis-lex (7 files directly, plus the real trigger behind several
+"cascade" long-tail entries and gold-H) is the standout.


### PR DESCRIPTION
A living checklist (`benchmark/coverage-gaps.md`) of constructs the grammar
doesn't yet handle, clustered from the corpus benchmark — so we keep track of
what's left. Covers prototypes, Test2 builders, `x10` glued repeat, v-strings
with `_`, `continue {}`, hex floats, given/when, the gold-corpus singletons, and
the long tail; plus a "recently addressed" log.

Dev-only (under `benchmark/`, so export-ignored and excluded from releases).
