### PR TITLE
Fix fat-comma + empty list slot in string-led hashrefs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -763,8 +763,16 @@ module.exports = grammar({
 
     // we use the precedence here to ensure that we turn map { q'thingy" => $_ } into a hashref
     // it just needs to be arbitrarily higher than the _literal rule.
-    _tricky_list: $ => prec(1, seq(
-      choice($.string_literal, $.interpolated_string_literal, $.command_string, $.autoquoted_bareword, $.number), $._PERLY_COMMA, $._listexpr
+    // The tail mirrors `_term_rightward` (flat list + empty/trailing slots) rather
+    // than delegating to `_listexpr` — a delegated `_listexpr` can't begin with a
+    // comma, so `{ hi =>, 'thing' }` (a fat comma followed by an empty slot, valid
+    // Perl) used to error. Inlining the empty-slot-aware repeat also flattens the
+    // list instead of nesting a second `list_expression` after the first comma.
+    _tricky_list: $ => prec.right(1, seq(
+      choice($.string_literal, $.interpolated_string_literal, $.command_string, $.autoquoted_bareword, $.number),
+      $._PERLY_COMMA,
+      repeat(seq(optional($._term), $._PERLY_COMMA)),
+      optional($._term),
     )),
     anonymous_hash_expression: $ => choice(
       seq($._PERLY_BRACE_OPEN, $._expr, '}'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4525,7 +4525,7 @@
       ]
     },
     "_tricky_list": {
-      "type": "PREC",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",
@@ -4560,8 +4560,40 @@
             "name": "_PERLY_COMMA"
           },
           {
-            "type": "SYMBOL",
-            "name": "_listexpr"
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_term"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_PERLY_COMMA"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_term"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }

--- a/test/corpus/autoquote
+++ b/test/corpus/autoquote
@@ -346,3 +346,40 @@ $thing ? -hi:-there;      # but single colon is not included in the quote
       (autoquoted_bareword)
       (autoquoted_bareword)))
   (comment))
+
+================================================================================
+Fat comma followed by empty list slots (valid Perl, flattens away)
+================================================================================
+{ hi =>, 'thing' };
+{ hi =>, };
+{ 'a', 'b', 'c' };
+{ 'a',, 'b' };
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (anonymous_hash_expression
+      (list_expression
+        (autoquoted_bareword)
+        (string_literal
+          (string_content)))))
+  (expression_statement
+    (anonymous_hash_expression
+      (list_expression
+        (autoquoted_bareword))))
+  (expression_statement
+    (anonymous_hash_expression
+      (list_expression
+        (string_literal
+          (string_content))
+        (string_literal
+          (string_content))
+        (string_literal
+          (string_content)))))
+  (expression_statement
+    (anonymous_hash_expression
+      (list_expression
+        (string_literal
+          (string_content))
+        (string_literal
+          (string_content))))))

--- a/test/corpus/functions
+++ b/test/corpus/functions
@@ -309,10 +309,9 @@ for_sure_a_hash { hi => 'there' }, 9001;
       (anonymous_hash_expression
         (list_expression
           (number)
-          (list_expression
-            (number)
-            (number)
-            (number))))))
+          (number)
+          (number)
+          (number)))))
   (expression_statement
     (ambiguous_function_call_expression
       (function)


### PR DESCRIPTION
## The bug

`{ hi =>, 'thing' }` is valid Perl — the fat comma autoquotes `hi`, and the trailing comma is an empty list slot that flattens away (`perl -ce` confirms it's `{'hi','thing'}`). But it produced an `ERROR` node, and the reduced `{ hi =>, }` recovered to a phantom zero-width `bareword`.

## Root cause

Both `,` and `=>` lex to `_PERLY_COMMA`, so `=>,` is two consecutive commas (an empty slot). The general list path (`_term_rightward`) already absorbs empty slots, but anon-hashes whose **first element is a string-like** route through the `_tricky_list` disambiguator, which was hardcoded as:

```
stringlike  _PERLY_COMMA  _listexpr
```

`_listexpr` can't *begin* with a comma, so the empty slot after `=>` had nowhere to land.

## Fix

Rewrote `_tricky_list` to inline the same empty-slot-aware tail as `_term_rightward` instead of delegating to `_listexpr`. As a deliberate side effect this also **flattens** the list — the old rule nested a second `list_expression` after the first comma (`{1,2,3,4}` → `list(number, list(number,number,number))`), an anomaly unique to this one construct. `{"hi",}` (trailing comma, single key) used to error too and now parses.

## Is the flattening breaking?

Swept it — **no**, and not even a minor by our schema-based semver rule:

- **`node-types.json` is byte-identical** before/after. The public taxonomy doesn't change.
- **Nested `list_expression` is still reachable & meaningful** elsewhere (`(1, (2, 3))` — real parenthesized sublists), so the schema always permitted list-in-list; consumers already had to handle it.
- **`_tricky_list` was the sole anomaly** — zero direct list-in-list nestings remain in the corpus. Every equivalent form was already flat.
- **`textobjects.scm` benefits**: `(list_expression (_) @parameter.inner)` matches direct children, so under the old nesting elements 2–N of a string-led hash were missed. Now captured.
- Downstream that peels list_expressions (semantically transparent): identical output. Downstream that assumed flat: was *wrong* before, *correct* now.

## Cost / tests

- +3 large states (3652 → 3655).
- Full corpus **283/283**. Added a regression block to `test/corpus/autoquote`; updated the one nested-form expectation in `test/corpus/functions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)