### PR TITLE
Fix wasm-build OOM from unicode bareword regex

### DIFF
--- a/lib/unicode_ranges.js
+++ b/lib/unicode_ranges.js
@@ -2,6 +2,11 @@
 module.exports = {
   // these patterns are simply XID_Start followed by XID_Continue, minus things which don't match perl's \p{Word}
   identifier: /[_\p{XID_Start}][\p{XID_Continue}]*/v,
-  // this adds in any amount of :: before or in between identifiers
-  bareword:   /((::)|([_\p{XID_Start}][\p{XID_Continue}]*))+/v,
+  // Any amount of :: before/between/after identifiers. NOTE the anchored shape:
+  // the repeat re-enters only on the `::` literal, never directly back into the
+  // huge XID class. The "obvious" form ((::)|IDENT)+ loops the repeat over an
+  // alternation containing XID_Continue, which makes clang's wasm codegen blow
+  // up to >16GB and OOM the release runner (same family as tree-sitter#3496).
+  // Keep this anchored; do not "simplify" it back to (A|B)+.
+  bareword:   /(::)*[_\p{XID_Start}][\p{XID_Continue}]*((::)+[_\p{XID_Start}][\p{XID_Continue}]*)*(::)*|(::)+/v,
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9936,7 +9936,7 @@
         },
         {
           "type": "PATTERN",
-          "value": "((::)|([_\\p{XID_Start}][\\p{XID_Continue}]*))+",
+          "value": "(::)*[_\\p{XID_Start}][\\p{XID_Continue}]*((::)+[_\\p{XID_Start}][\\p{XID_Continue}]*)*(::)*|(::)+",
           "flags": "v"
         }
       ]

--- a/unicode_ranges.pl
+++ b/unicode_ranges.pl
@@ -90,7 +90,12 @@ path('./lib/unicode_ranges.js')->spew(<<JS);
 module.exports = {
   // these patterns are simply XID_Start followed by XID_Continue, minus things which don't match perl's \\p{Word}
   identifier: /[_\\p{XID_Start}][\\p{XID_Continue}]*/v,
-  // this adds in any amount of :: before or in between identifiers
-  bareword:   /((::)|([_\\p{XID_Start}][\\p{XID_Continue}]*))+/v,
+  // Any amount of :: before/between/after identifiers. NOTE the anchored shape:
+  // the repeat re-enters only on the `::` literal, never directly back into the
+  // huge XID class. The "obvious" form ((::)|IDENT)+ loops the repeat over an
+  // alternation containing XID_Continue, which makes clang's wasm codegen blow
+  // up to >16GB and OOM the release runner (same family as tree-sitter#3496).
+  // Keep this anchored; do not "simplify" it back to (A|B)+.
+  bareword:   /(::)*[_\\p{XID_Start}][\\p{XID_Continue}]*((::)+[_\\p{XID_Start}][\\p{XID_Continue}]*)*(::)*|(::)+/v,
 }
 JS


### PR DESCRIPTION
## What broke

The v1.1.4 **Publish** workflow failed building the wasm artifact with exit code 143 (SIGTERM). It was not a blip and not a tree-sitter CLI version regression — it reproduces on v0.26.9 (the CLI that built v1.1.3) as well.

**Root cause:** #254 made `_bareword` unicode-aware with the shape `((::)|IDENT)+` — a `repeat1` looping back over an *alternation that contains the full XID_Continue class*. tree-sitter's lexer compiler explodes the combined character-set tables, and clang's wasm codegen then needs **>16 GB RAM** to compile `parser.c` → OOM-killed on GitHub's 16 GB runner. Same failure family as the already-documented [tree-sitter/tree-sitter#3496](https://github.com/tree-sitter/tree-sitter/issues/3496) (there's a scar comment about it in `unicode_ranges.pl`). v1.1.3 squeaked under the limit; v1.1.4's larger parser tipped over.

## The fix

Re-anchor the repeat on the `::` literal (disjoint from XID — colons aren't word chars — so the repeat never re-enters the huge class):

```
before:  ((::)|([_\p{XID_Start}][\p{XID_Continue}]*))+
after:   (::)*[_\p{XID_Start}][\p{XID_Continue}]*((::)+[_\p{XID_Start}][\p{XID_Continue}]*)*(::)*|(::)+
```

Full XID_Start/XID_Continue coverage kept. **Identical accepted language** — verified against the `package;` corpus test, including the pathological `package ::` (lone `::`) and `package ::butwhy::::::` cases, which parse byte-identically.

## Measured (parser.c → wasm under a 16 GB cgroup cap)

| | peak RAM | result |
|---|---|---|
| before | **>16 GiB** | OOM-killed, no wasm |
| after | **~300 MiB** | 3 s, valid 4.76 MB wasm |

- Full corpus **283/283**
- Real end-to-end `./tree-sitter build --wasm .` succeeds
- Fix is in the generator (`unicode_ranges.pl`) + generated `lib/unicode_ranges.js`; `src/grammar.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z8ScgQVf9daPjSnxxP6jY