### PR TITLE
Include license file when packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 autoexamples = false
 
 build = "bindings/rust/build.rs"
-include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*", "lib/*"]
+include = ["LICENSE", "bindings/rust/*", "grammar.js", "queries/*", "src/*", "lib/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"


### PR DESCRIPTION
This is required by the MIT license terms; discovered when packaging this in Fedora

```
$ cargo package --list --allow-dirty | grep LICENSE
LICENSE
```