### PR TITLE
Field/query correctness: fix field-splat bugs + add parenthesized_expression node (v1.3.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ts-parser-perl"
 description = "Actively maintained tree-sitter grammar for Perl"
-version = "1.2.1"
+version = "1.3.0"
 license = "MIT"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "perl"]

--- a/grammar.js
+++ b/grammar.js
@@ -580,6 +580,13 @@ module.exports = grammar({
         seq(field('hashref', $._term), '->', '%', $._slice_key_subscript)),
     ),
 
+    // A parenthesized expression is its own node rather than a transparent
+    // `('(' _expr ')')`: a field wrapping a transparent-paren term (e.g. binop's
+    // `right:`) otherwise splats onto the `(`/`)` tokens, since tree-sitter
+    // attaches a field to every child spliced up from a hidden/inline rule (see
+    // upstream tree-sitter#1526). Every mature grammar (js/python/c/rust) gives
+    // parens a named node for exactly this reason. Costs zero extra parser states.
+    parenthesized_expression: $ => seq('(', $._expr, ')'),
     _term: $ => choice(
       $.readline_expression,
       $.fileglob_expression,
@@ -601,7 +608,7 @@ module.exports = grammar({
       $.conditional_expression,
       $.refgen_expression,
       $.localization_expression,
-      seq('(', $._expr, ')'),
+      $.parenthesized_expression,
       $.quoted_word_list,
       $.heredoc_token,
       $.command_heredoc_token,

--- a/grammar.js
+++ b/grammar.js
@@ -851,7 +851,7 @@ module.exports = grammar({
           // Unambiguous: the variable always starts with a sigil, never a bareword.
           seq(optional(field('type', $.package)), field('variable', $._declared_vars)),
           field('variable', $.refalias_variable),
-          field('variables', $._decl_variable_list)),
+          $._decl_variable_list),
         optseq(':', optional(field('attributes', $.attrlist))))
     ),
 
@@ -863,8 +863,8 @@ module.exports = grammar({
     // first element (while still allowing empty/trailing slots after a comma)
     // keeps the nested-group `(` unambiguous.
     _decl_variable_list_body: $ => seq(
-      $._decl_variable_list_element,
-      repeat(seq(',', optional($._decl_variable_list_element)))
+      field('variables', $._decl_variable_list_element),
+      repeat(seq(',', optional(field('variables', $._decl_variable_list_element))))
     ),
 
     _decl_variable_list_element: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -431,7 +431,7 @@ module.exports = grammar({
     _for_initializer: $ => choice(
       seq(optional(choice('my', 'state', 'our')), field('variable', $.scalar)),
       seq(optional(choice('my', 'state', 'our')), field('variable', $.refalias_variable)),
-      seq('my', field('variables', paren_list_of($.scalar))),
+      seq('my', paren_list_of(field('variables', $.scalar))),
     ),
     for_statement: $ =>
       seq($._KW_FOR,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-perl",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A tree-sitter parser, for Perl!",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-perl"
 description = "Perl grammar for tree-sitter"
-version = "1.2.1"
+version = "1.3.0"
 keywords = ["incremental", "parsing", "tree-sitter", "perl"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2969,6 +2969,23 @@
         }
       ]
     },
+    "parenthesized_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "_term": {
       "type": "CHOICE",
       "members": [
@@ -3053,21 +3070,8 @@
           "name": "localization_expression"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "("
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_expr"
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5018,12 +5018,8 @@
                 }
               },
               {
-                "type": "FIELD",
-                "name": "variables",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_decl_variable_list"
-                }
+                "type": "SYMBOL",
+                "name": "_decl_variable_list"
               }
             ]
           },
@@ -5092,8 +5088,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_decl_variable_list_element"
+          "type": "FIELD",
+          "name": "variables",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_decl_variable_list_element"
+          }
         },
         {
           "type": "REPEAT",
@@ -5108,8 +5108,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_decl_variable_list_element"
+                    "type": "FIELD",
+                    "name": "variables",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_decl_variable_list_element"
+                    }
                   },
                   {
                     "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1630,57 +1630,61 @@
               "value": "my"
             },
             {
-              "type": "FIELD",
-              "name": "variables",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "scalar"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "CHOICE",
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "scalar"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "FIELD",
+                            "name": "variables",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "scalar"
+                            }
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
                       },
                       {
-                        "type": "BLANK"
+                        "type": "STRING",
+                        "value": ","
                       }
                     ]
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ")"
                   }
-                ]
-              }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "FIELD",
+                      "name": "variables",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "scalar"
+                      }
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
             }
           ]
         }

--- a/test/corpus/map-grep
+++ b/test/corpus/map-grep
@@ -41,13 +41,14 @@ map { lc($_) => 1 } @array;        # and this.
     (map_grep_expression
       (block
         (expression_statement
-          (list_expression
-            (interpolated_string_literal
-              (string_content
-                (escape_sequence)
-                (scalar
-                  (varname))))
-            (number))))
+          (parenthesized_expression
+            (list_expression
+              (interpolated_string_literal
+                (string_content
+                  (escape_sequence)
+                  (scalar
+                    (varname))))
+              (number)))))
       (array
         (varname))))
   (comment)
@@ -78,11 +79,12 @@ map { even_this   => $_ }, @array;     # perl guesses EXPR; slightly more SURPRI
   (expression_statement
     (map_grep_expression
       (unary_expression
-        (list_expression
-          (func1op_call_expression
-            (scalar
-              (varname)))
-          (number)))
+        (parenthesized_expression
+          (list_expression
+            (func1op_call_expression
+              (scalar
+                (varname)))
+            (number))))
       (array
         (varname))))
   (comment)
@@ -174,11 +176,12 @@ map +(lc($_) => 1 ), (1, 2), 3;
   (expression_statement
     (map_grep_expression
       callback: (unary_expression
-        operand: (list_expression
-          (func1op_call_expression
-            (scalar
-              (varname)))
-          (number)))
+        operand: (parenthesized_expression
+          (list_expression
+            (func1op_call_expression
+              (scalar
+                (varname)))
+            (number))))
       list: (list_expression
         (number)
         (number)
@@ -192,22 +195,25 @@ map +(lc($_) => 1 ), (1, 2), 3;
               (scalar
                 (varname)))
             (number))))
-      list: (list_expression
-        (number)
-        (number)
-        (number))))
+      list: (parenthesized_expression
+        (list_expression
+          (number)
+          (number)
+          (number)))))
   (expression_statement
     (map_grep_expression
       callback: (unary_expression
-        operand: (list_expression
-          (func1op_call_expression
-            (scalar
-              (varname)))
-          (number)))
+        operand: (parenthesized_expression
+          (list_expression
+            (func1op_call_expression
+              (scalar
+                (varname)))
+            (number))))
       list: (list_expression
-        (list_expression
-          (number)
-          (number))
+        (parenthesized_expression
+          (list_expression
+            (number)
+            (number)))
         (number)))))
 
 ================================================================================
@@ -260,10 +266,11 @@ sort $not_subref, 1;
   (expression_statement
     (sort_expression
       callback: (function)
-      list: (list_expression
-        (number)
-        (number)
-        (number))))
+      list: (parenthesized_expression
+        (list_expression
+          (number)
+          (number)
+          (number)))))
   (expression_statement
     (sort_expression
       list: (unary_expression

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -269,16 +269,18 @@ EXPR < EXPR - list/non assoc
     (number))
   (expression_statement
     (relational_expression
-      (relational_expression
-        (number)
-        (number))
+      (parenthesized_expression
+        (relational_expression
+          (number)
+          (number)))
       (number)))
   (expression_statement
     (relational_expression
       (number)
-      (relational_expression
-        (number)
-        (number)))))
+      (parenthesized_expression
+        (relational_expression
+          (number)
+          (number))))))
 
 ================================================================================
 < and eq - list/non assoc corner cases
@@ -448,9 +450,10 @@ EXPR ** EXPR
   (expression_statement
     (binary_expression
       left: (number)
-      right: (binary_expression
-        left: (number)
-        right: (number)))))
+      right: (parenthesized_expression
+        (binary_expression
+          left: (number)
+          right: (number))))))
 
 ================================================================================
 !EXPR
@@ -563,9 +566,10 @@ range ops
   (expression_statement
     (binary_expression
       (number)
-      (binary_expression
-        (number)
-        (number)))))
+      (parenthesized_expression
+        (binary_expression
+          (number)
+          (number))))))
 
 ================================================================================
 range ops - nonassoc
@@ -899,7 +903,8 @@ my $c = $s x 3;
         (array
           (varname)))
       (binary_expression
-        (interpolated_string_literal)
+        (parenthesized_expression
+          (interpolated_string_literal))
         (number))))
   (expression_statement
     (assignment_expression

--- a/test/corpus/subroutines
+++ b/test/corpus/subroutines
@@ -192,11 +192,12 @@ sub barN ($x, $y, @z) { }
       (optional_parameter
         (scalar
           (varname))
-        (binary_expression
-          (scalar
-            (varname))
-          (scalar
-            (varname)))))
+        (parenthesized_expression
+          (binary_expression
+            (scalar
+              (varname))
+            (scalar
+              (varname))))))
     (block))
   (subroutine_declaration_statement
     (bareword)
@@ -392,6 +393,7 @@ lexical method calls experimental Object::Pad syntax
 ================================================================================
 $sner->&over_9000
 --------------------------------------------------------------------------------
+
 (source_file
   (expression_statement
     (method_call_expression

--- a/test/corpus/variables
+++ b/test/corpus/variables
@@ -100,7 +100,8 @@ my ${ spaced };
       left: (variable_declaration
         variable: (array
           (varname)))
-      right: (number)))
+      right: (parenthesized_expression
+        (number))))
   (expression_statement
     (assignment_expression
       left: (variable_declaration
@@ -183,17 +184,19 @@ my %h = (6, 7);
       (variable_declaration
         (array
           (varname)))
-      (list_expression
-        (number)
-        (number))))
+      (parenthesized_expression
+        (list_expression
+          (number)
+          (number)))))
   (expression_statement
     (assignment_expression
       (variable_declaration
         (hash
           (varname)))
-      (list_expression
-        (number)
-        (number)))))
+      (parenthesized_expression
+        (list_expression
+          (number)
+          (number))))))
 
 ================================================================================
 variable declarations with attributes


### PR DESCRIPTION
Bundles three related field/query-correctness fixes for one release (v1.3.0). All share one root cause: **tree-sitter attaches a field to every child spliced up from a hidden/inline rule** (upstream [tree-sitter#1526](https://github.com/tree-sitter/tree-sitter/issues/1526) — open, no fix, no grammar knob), so a field wrapping a paren-bearing construct splats onto the `(`/`)` tokens.

## 1. `variable_declaration` variables (patch-level, schema-identical)
`field('variables', $._decl_variable_list)` wrapped `seq('(', body, ')')`, so `(variable_declaration variables: _)` matched the leading `(`. Pushed the field onto the individual elements. `my ($a, $b)` → `variables:` now yields `$a`, `$b`.

## 2. `_for_initializer` variables (patch-level, schema-identical)
Same shape via `paren_list_of(...)` in `for my ($a, $b) (@list)`. Same fix.

## 3. `parenthesized_expression` node (minor — new node type)
`_term` matched `(EXPR)` as a transparent inline `('(' _expr ')')` with no node boundary, so **every** fielded term position splatted onto parens when the operand was parenthesized: binop `left:`/`right:`, unary `operand:`, ternary `condition:`, map/grep `list:`, etc. `(assignment_expression right: _)` returned `(`.

Fix: give parens a named `parenthesized_expression` node — the upstream-recommended remedy and what every mature grammar (js/python/c/rust) does. The field lands cleanly on the wrapper.
- **Zero extra parser states** (LARGE_STATE_COUNT unchanged) — the shape was already present.
- `list_expression` retained: orthogonal (comma-list grouping, appears with or without parens); still distinguishes `($a,$b)` from `($x)`.
- A `tuple`-style merge (fold parens into the list node) was evaluated and rejected: it conflicts with the `_term_rightward` list-op gobbling machinery.

## Versioning
Adds a node type → **minor** bump 1.2.1 → 1.3.0 per the node-types schema rule. Corpus re-blessed (wrapper insertions only; the nonassoc-`isa` ERROR fixture updated by hand since `--update` skips error-bearing tests).

`./tree-sitter test`: 283/283, all highlight assertions clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)